### PR TITLE
Add CSP to response headers

### DIFF
--- a/app/controllers/pafs_core/application_controller.rb
+++ b/app/controllers/pafs_core/application_controller.rb
@@ -1,23 +1,25 @@
 # Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
+
 module PafsCore
   class ApplicationController < ActionController::Base
     include PafsCore::ApplicationHelper
+    include PafsCore::CustomHeaders
+
     protect_from_forgery with: :exception
 
-    before_filter :set_cache_headers
+    before_action :custom_headers
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
 
-  private
+    private
+
     def raise_not_found
       raise ActionController::RoutingError.new("Not Found")
     end
 
-    def set_cache_headers
-      response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate, private"
-      response.headers["Pragma"] = "no-cache"
-      response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    def custom_headers
+      response_headers!(response)
     end
 
     def handle_invalid_authenticity_token(exception)
@@ -27,5 +29,6 @@ module PafsCore
 
       render "pafs_core/errors/invalid_authenticity_token", status: :forbidden
     end
+
   end
 end

--- a/lib/pafs_core.rb
+++ b/lib/pafs_core.rb
@@ -23,6 +23,7 @@ require "pafs_core/file_types"
 require "pafs_core/files"
 require "pafs_core/fcerm1"
 require "pafs_core/email"
+require "pafs_core/custom_headers"
 require "core_ext/time/financial"
 require "core_ext/date/financial"
 

--- a/lib/pafs_core/custom_headers.rb
+++ b/lib/pafs_core/custom_headers.rb
@@ -1,0 +1,41 @@
+# Play nice with Ruby 3 (and rubocop)
+# frozen_string_literal: true
+
+module PafsCore
+  module CustomHeaders
+
+    # Intended to be used in ApplicationController's, specifically from a
+    # before_action() in order to update the response headers.
+    def response_headers!(response)
+      # Cache buster, specifically we don't want the client to cache any
+      # responses from the service
+      response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate, private"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+
+      # Added in response to initial PEN test. A Content-Security-Policy
+      # > is delivered via a HTTP response header, much like HSTS, and defines
+      # > approved sources of content that the browser may load. It can be an
+      # > effective countermeasure to Cross Site Scripting (XSS) attacks and is
+      # > also widely supported and usually easily deployed.
+      # https://scotthelme.co.uk/content-security-policy-an-introduction/
+      #
+      # Specifically here we are saying
+      # - scripts can only come from the service, however we permit
+      #   unsafe-inlinescripts
+      # - fonts can only come from the service, or via the data: scheme
+      # - send any violation reports to a service we have setup for CSP
+      # - for all other items their soiurce must be the service (default-src)
+      #
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+      response
+        .headers["Content-Security-Policy"] = "default-src 'self'; "\
+                                              "script-src 'self' 'unsafe-inline'; "\
+                                              "font-src 'self' data:; "\
+                                              "report-uri https://environmentagency.report-uri.io/r/default/csp/enforce"
+    end
+
+  end
+end

--- a/spec/lib/pafs_core/custom_headers_spec.rb
+++ b/spec/lib/pafs_core/custom_headers_spec.rb
@@ -1,0 +1,40 @@
+# Play nice with Ruby 3 (and rubocop)
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe PafsCore::CustomHeaders do
+  before(:each) do
+    @response = OpenStruct.new
+    @response.headers = {}
+    @response
+  end
+
+  describe "#response_headers!" do
+    let(:dummy_controller) do
+      Class.new { include PafsCore::CustomHeaders }.new
+    end
+
+    context "Cache busting" do
+      it "sets the necessary headers to prevent caching in the browser" do
+        dummy_controller.response_headers!(@response)
+
+        expect(@response.headers["Cache-Control"]).to eq "no-cache, no-store, max-age=0, must-revalidate, private"
+        expect(@response.headers["Pragma"]).to eq "no-cache"
+        expect(@response.headers["Expires"]).to eq "Fri, 01 Jan 1990 00:00:00 GMT"
+      end
+    end
+
+    context "Content security policy" do
+      it "sets the necessary headers to ensure all content comes from the site's origin" do
+        dummy_controller.response_headers!(@response)
+
+        expect(@response.headers["Content-Security-Policy"]).to eq(
+          "default-src 'self'; "\
+          "script-src 'self' 'unsafe-inline'; "\
+          "font-src 'self' data:; "\
+          "report-uri https://environmentagency.report-uri.io/r/default/csp/enforce"
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,14 +44,14 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-286

Following a PEN test it was flagged that the service has not specified a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in the response headers sent back from the app to the clients browser.

For reference CSP

> [..] is an HTTP response header that restricts the browser to loading external assets such as scripts, styles or media from a wide variety of sources — as well as inline scripts. It is intended to prevent wide categories of attacks, such as cross-site scripting (XSS), click-jacking and other forms of code injection.
>
> *https://blog.sqreen.io/integrating-content-security-policy-into-your-rails-applications-4f883eed8f45/*

Prior to this change we had logic that set custom headers via a `before_filter` in the `ApplicationController`. The issue found in testing was that only pages that originated in **pafs_core** had these headers applied. To ensure all pages from either the front or back office apps get the new CSP we first needed to refactor the setting of the headers to a module, and then update `ApplicationController` in **pafs_core** to set the response headers using the new module. The same change will be made to the [pafs-user](https://github.com/DEFRA/pafs-user) and [pafs-admin](https://github.com/DEFRA/pafs-admin) `ApplicationController`'s.

N.B. Ideally we would have liked to not set the policy for `script-src` to allow `unsafe-inline`, but currently the GOV.UK template makes use of inline JavaScript. CSP is fine with you allowing inline scripts, but ideally wants you to uniquely identify them using a nonce or sha. The team behind the template are aware of this though (See [Inline scripts need hashes provided for CSP directives](alphagov/govuk_template#258)) so hopefully once a solution is in place we can update our policy.