### PR TITLE
Add ability 2 generate file with multiple projects

### DIFF
--- a/app/assets/stylesheets/pafs_core/_projects.scss
+++ b/app/assets/stylesheets/pafs_core/_projects.scss
@@ -609,6 +609,19 @@ $icon-shadow-colour: rgba(0, 0, 0, 0.4);
   }
 }
 
+.download-all-proposals-link {
+  @include core-16;
+
+  margin-bottom: 0.5em;
+  margin-top: -2.5em;
+  text-align: right;
+
+  @include media(mobile) {
+    margin-top: auto;
+    text-align: left;
+  }
+}
+
 .error-page {
   text-align: center;
 
@@ -654,5 +667,3 @@ $icon-shadow-colour: rgba(0, 0, 0, 0.4);
 .risk-summary-subheading {
   text-align: right;
 }
-
-

--- a/app/controllers/pafs_core/downloads_controller.rb
+++ b/app/controllers/pafs_core/downloads_controller.rb
@@ -1,5 +1,7 @@
 # Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
+require "zip"
+
 class PafsCore::DownloadsController < PafsCore::ApplicationController
   include PafsCore::Files
 
@@ -41,6 +43,24 @@ class PafsCore::DownloadsController < PafsCore::ApplicationController
     end
   end
 
+  def benefit_areas
+    tmpfile = Tempfile.new
+    # make tmpfile an empty Zipfile
+    Zip::OutputStream.open(tmpfile) { |_| }
+    # now we can open the temporary zipfile
+    Zip::File.open(tmpfile.path, Zip::File::CREATE) do |zf|
+      navigator.find_apt_projects.each do |project|
+        fetch_benefit_area_file_for(project) do |data, filename, _content_type|
+          zf.get_output_stream(filename) { |f| f.write(data) }
+        end
+      end
+    end
+    send_data(File.read(tmpfile.path), type: "application/zip", filename: "benefit_areas.zip")
+  ensure
+    tmpfile.close
+    tmpfile.unlink
+  end
+
   # GET
   def delete_benefit_area
     @project = navigator.find(params[:id])
@@ -71,6 +91,24 @@ class PafsCore::DownloadsController < PafsCore::ApplicationController
                 filename: filename,
                 type: content_type)
     end
+  end
+
+  def moderations
+    tmpfile = Tempfile.new
+    # make tmpfile an empty Zipfile
+    Zip::OutputStream.open(tmpfile) { |_| }
+    # now we can open the temporary zipfile
+    Zip::File.open(tmpfile.path, Zip::File::CREATE) do |zf|
+      navigator.find_apt_projects.each do |project|
+        generate_moderation_for(project) do |data, filename, _content_type|
+          zf.get_output_stream(filename) { |f| f.write(data) }
+        end
+      end
+    end
+    send_data(File.read(tmpfile.path), type: "application/zip", filename: "moderations.zip")
+  ensure
+    tmpfile.close
+    tmpfile.unlink
   end
 
   private

--- a/app/controllers/pafs_core/downloads_controller.rb
+++ b/app/controllers/pafs_core/downloads_controller.rb
@@ -7,6 +7,10 @@ class PafsCore::DownloadsController < PafsCore::ApplicationController
     @project = PafsCore::ProjectSummaryPresenter.new navigator.find(params[:id])
   end
 
+  def all
+    @downloads = PafsCore::ProjectsDownloadPresenter.new navigator.find_apt_projects
+  end
+
   def proposal
     @project = PafsCore::ProjectSummaryPresenter.new navigator.find(params[:id])
 
@@ -22,6 +26,13 @@ class PafsCore::DownloadsController < PafsCore::ApplicationController
         send_data xlsx.stream.read,
           filename: fcerm1_filename(@project.reference_number, :xlsx)
       end
+    end
+  end
+
+  def proposals
+    projects = navigator.find_apt_projects
+
+    projects.each do |project|
     end
   end
 

--- a/app/controllers/pafs_core/downloads_controller.rb
+++ b/app/controllers/pafs_core/downloads_controller.rb
@@ -30,10 +30,8 @@ class PafsCore::DownloadsController < PafsCore::ApplicationController
   end
 
   def proposals
-    projects = navigator.find_apt_projects
-
-    projects.each do |project|
-    end
+    xlsx = generate_multi_fcerm1(navigator.find_apt_projects, :xlsx)
+    send_data xlsx.stream.read, filename: "fcerm_proposals.xlsx"
   end
 
   def benefit_area

--- a/app/controllers/pafs_core/projects_controller.rb
+++ b/app/controllers/pafs_core/projects_controller.rb
@@ -39,7 +39,8 @@ class PafsCore::ProjectsController < PafsCore::ApplicationController
     @project.submission_state.submit!
 
     # send files to asite
-    asite.submit_project(@project)
+    # asite.submit_project(@project)
+    PafsCore::AsiteSubmissionJob.perform_later(@project)
 
     redirect_to pafs_core.confirm_project_path(@project)
   end
@@ -120,7 +121,7 @@ private
     @navigator ||= PafsCore::ProjectNavigator.new current_resource
   end
 
-  def asite
-    @asite ||= PafsCore::AsiteService.new current_resource
-  end
+  # def asite
+  #   @asite ||= PafsCore::AsiteService.new current_resource
+  # end
 end

--- a/app/controllers/pafs_core/projects_controller.rb
+++ b/app/controllers/pafs_core/projects_controller.rb
@@ -9,7 +9,6 @@ class PafsCore::ProjectsController < PafsCore::ApplicationController
     # (filterable) list of projects
     page = params.fetch(:page, 1)
     projects_per_page = params.fetch(:per, 10)
-
     @projects = navigator.search(params).page(page).per(projects_per_page)
   end
 

--- a/app/helpers/pafs_core/projects_helper.rb
+++ b/app/helpers/pafs_core/projects_helper.rb
@@ -13,6 +13,10 @@ module PafsCore
       current_resource.respond_to?(:primary_area) && current_resource.primary_area.pso_area?
     end
 
+    def ea_user?
+      current_resource.respond_to?(:primary_area) && current_resource.primary_area.ea_area?
+    end
+
     def status_label_for(state)
       scope = "pafs_core.projects.status"
       scope = scope + ".rma" if rma_user?

--- a/app/jobs/pafs_core/asite_submission_job.rb
+++ b/app/jobs/pafs_core/asite_submission_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module PafsCore
+  class AsiteSubmissionJob < ActiveJob::Base
+    queue_as :default
+
+    def perform(project)
+      PafsCore::AsiteService.new.submit_project(project)
+    end
+  end
+end

--- a/app/models/pafs_core/state.rb
+++ b/app/models/pafs_core/state.rb
@@ -4,6 +4,10 @@ module PafsCore
     belongs_to :project, inverse_of: :state
     validates :state, inclusion: { in: %w[draft completed submitted updatable updated finished] }
 
+    def self.submitted
+      where(state: "submitted")
+    end
+
     def self.refreshable
       # states that can be "opened" during programme refresh
       where(state: %w[completed submitted updated finished])

--- a/app/presenters/pafs_core/projects_download_presenter.rb
+++ b/app/presenters/pafs_core/projects_download_presenter.rb
@@ -15,7 +15,12 @@ module PafsCore
     end
 
     def urgency_count
-      projects.count
+      @urgency_count ||= calc_urgency_count
+    end
+
+  private
+    def calc_urgency_count
+      projects.where.not(urgency_reason: "not_urgent").count
     end
   end
 end

--- a/app/presenters/pafs_core/projects_download_presenter.rb
+++ b/app/presenters/pafs_core/projects_download_presenter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module PafsCore
+  class ProjectsDownloadPresenter
+    attr_reader :projects
+    def initialize(projects)
+      @projects = projects
+    end
+
+    def count
+      projects.count
+    end
+
+    def shapefile_count
+      projects.count
+    end
+
+    def urgency_count
+      projects.count
+    end
+  end
+end

--- a/app/services/pafs_core/asite_service.rb
+++ b/app/services/pafs_core/asite_service.rb
@@ -48,7 +48,7 @@ module PafsCore
       end
 
       # generate attachments and send to asite
-      PafsCore::AsiteMailer.submit_project(project.slug, attachments).deliver_later
+      PafsCore::AsiteMailer.submit_project(project.slug, attachments).deliver_now
 
       submission.submission_state.deliver!
     end

--- a/app/services/pafs_core/project_navigator.rb
+++ b/app/services/pafs_core/project_navigator.rb
@@ -44,7 +44,12 @@ module PafsCore
       project_service.find_project(ref_number)
     end
 
-    def search(options)
+    def find_apt_projects
+      project_service.submitted_projects
+    end
+
+    def search(options = {})
+      options[:state] = "submitted" if user.primary_area.ea_area?
       project_service.search(options)
     end
 

--- a/app/services/pafs_core/project_service.rb
+++ b/app/services/pafs_core/project_service.rb
@@ -39,18 +39,22 @@ module PafsCore
       "#{rfcc_code}C501E/%03dA/%03dA" % sequence_nos
     end
 
-    def search(options)
+    def search(options = {})
       areas = area_ids_for_user(user)
+
       sort_col = options[:sort_col];
       sort_order = options[:sort_order]
 
       sort_col = "updated_at" if sort_col.nil?
       sort_order = "desc" if sort_order.nil?
-      PafsCore::Project.
-        includes(:area_projects, :areas).
-        joins(:area_projects).
-        merge(PafsCore::AreaProject.where(area_id: areas)).
-        order("#{sort_col}": sort_order)
+      query = PafsCore::Project
+              .includes(:area_projects, :areas)
+              .joins(:area_projects)
+              .merge(PafsCore::AreaProject.where(area_id: areas))
+
+      query = query.joins(:state).merge(PafsCore::State.where(state: options[:state])) unless options[:state].nil?
+
+      query.order("#{sort_col}": sort_order)
     end
 
     def all_projects_for(area)

--- a/app/services/pafs_core/project_service.rb
+++ b/app/services/pafs_core/project_service.rb
@@ -30,6 +30,13 @@ module PafsCore
         first!
     end
 
+    def submitted_projects
+      PafsCore::Project.joins(:state).
+        merge(PafsCore::State.submitted).
+        joins(:area_projects).
+        merge(PafsCore::AreaProject.where(area_id: area_ids_for_user(user)))
+    end
+
     def find_project_without_security(id)
       PafsCore::Project.find_by!(slug: id.to_s.upcase)
     end

--- a/app/services/pafs_core/spreadsheet_service.rb
+++ b/app/services/pafs_core/spreadsheet_service.rb
@@ -44,6 +44,9 @@ module PafsCore
     end
 
     def add_project_to_sheet(sheet, project, row_no)
+      # multi project spreadsheets need additional rows to work with
+      sheet.insert_row(row_no) if row_no != FIRST_DATA_ROW
+
       FCERM1_COLUMN_MAP.each do |col|
         if col.fetch(:export, true)
           range = col.fetch(:date_range, false)

--- a/app/services/pafs_core/spreadsheet_service.rb
+++ b/app/services/pafs_core/spreadsheet_service.rb
@@ -15,6 +15,23 @@ module PafsCore
       workbook
     end
 
+    def generate_multi_xlsx(projects)
+      workbook = read_fcerm1_template
+      # until sheet names are fixed, take the first sheet in the workbook
+      sheet = workbook.worksheets[0]
+
+      row_number = FIRST_DATA_ROW
+      projects.each do |project|
+        add_project_to_sheet(
+          sheet,
+          PafsCore::SpreadsheetPresenter.new(project),
+          row_number
+        )
+        row_number += 1
+      end
+      workbook
+    end
+
     def generate_csv(project)
       CSV.generate do |csv|
         csv << %w[ not yet implemented ]

--- a/app/views/pafs_core/downloads/all.html.erb
+++ b/app/views/pafs_core/downloads/all.html.erb
@@ -2,7 +2,11 @@
 
 <h1 class="heading-large">Download all proposals</h1>
 <div class="sub-heading">
-  All <b><%= @downloads.count %></b> proposals are available for download.
+  <% if @downloads.count == 1 %>
+    There is <span class="bold-small">1</span> proposal available for download.
+  <% else %>
+    There are <span class="bold-small"><%= @downloads.count %></span> proposals available for download.
+  <% end %>
 </div>
 <div class="grid-row">
   <div class="column-third">
@@ -12,14 +16,20 @@
     <section class="projects-download-link">
       <div class="attachment">
         <div class="attachment-thumb">
-          <%= link_to image_tag("pafs_core/pub-cover-spreadsheet.png"), pafs_core.proposals_downloads_path, class: "thumbnail" %>
+          <%= link_to image_tag("pafs_core/pub-cover-spreadsheet.png"), pafs_core.proposals_downloads_path(format: :xslx), class: "thumbnail" %>
         </div>
         <div class="attachment-details">
-          <%= link_to "Proposal (Excel document)", pafs_core.proposals_downloads_path, class: "font-medium" %>
+          <%= link_to "Proposal (Excel document)", pafs_core.proposals_downloads_path(format: :xslx), class: "font-medium" %>
           <p class="font-xsmall">MS Excel Spreadsheet</p>
-          <p class="font-xsmall">There are <%= @downloads.count %> proposals</p>
           <p class="font-xsmall">
-            This is formatted in the same way as the old spreadsheet, for convenience.
+            <% if @downloads.count == 1 %>
+              There is 1 proposal
+            <% else %>
+              There are <%= @downloads.count %> proposals
+            <% end %>
+          </p>
+          <p class="font-xsmall">
+            This is formatted in the same way as the old spreadsheet for convenience.
           </p>
         </div>
       </div>
@@ -27,15 +37,19 @@
     <section class="projects-download-link">
       <div class="attachment">
         <div class="attachment-thumb">
-          <%= link_to image_tag("pafs_core/pub-cover-shapefile.png"), pafs_core.benefit_areas_downloads_path, class: "thumbnail" %>
+          <%= link_to image_tag("pafs_core/pub-cover-zip.png"), pafs_core.benefit_areas_downloads_path(format: :zip), class: "thumbnail" %>
         </div>
         <div class="attachment-details">
-          <%= link_to "Project benefit area files (zip file)", pafs_core.benefit_areas_downloads_path, class: "font-medium" %>
+          <%= link_to "Project benefit area files (zip file)", pafs_core.benefit_areas_downloads_path(format: :zip), class: "font-medium" %>
           <p class="font-xsmall">
-            Compressed folder containing shapefiles for all <%= @downloads.shapefile_count %> proposals (zip file)
+            Compressed folder containing shapefiles for <%= @downloads.shapefile_count %> <%= "proposal".pluralize(@downloads.shapefile_count) %> (zip file)
           </p>
           <p class="font-xsmall">
-            <%= @downloads.shapefile_count %> proposals have benefit area files
+            <% if @downloads.shapefile_count == 1 %>
+              1 proposal has a benefit area file
+            <% else %>
+              <%= @downloads.shapefile_count %> proposals have benefit area files
+            <% end %>
           </p>
         </div>
       </div>
@@ -44,15 +58,19 @@
       <section class="projects-download-link">
         <div class="attachment">
           <div class="attachment-thumb">
-            <%= link_to image_tag("pafs_core/pub-cover-doc.png"), pafs_core.moderations_downloads_path, class: "thumbnail" %>
+            <%= link_to image_tag("pafs_core/pub-cover-zip.png"), pafs_core.moderations_downloads_path(format: :zip), class: "thumbnail" %>
           </div>
           <div class="attachment-details">
-            <%= link_to "Urgency moderation evidence", pafs_core.moderations_downloads_path, class: "font-medium" %>
+            <%= link_to "Urgency moderation evidence (zip file)", pafs_core.moderations_downloads_path(format: :zip), class: "font-medium" %>
             <p class="font-xsmall">
               Compressed folder containing urgency moderation evidence for <%= @downloads.urgency_count %> proposals (zip file)
             </p>
             <p class="font-xsmall">
-              <%= @downloads.urgency_count %> proposals have urgency moderation evidence
+              <% if @downloads.urgency_count == 1 %>
+                1 proposal has urgency moderation evidence
+              <% else %>
+                <%= @downloads.urgency_count %> proposals have urgency moderation evidence
+              <% end %>
             </p>
           </div>
         </div>

--- a/app/views/pafs_core/downloads/all.html.erb
+++ b/app/views/pafs_core/downloads/all.html.erb
@@ -1,0 +1,62 @@
+<% content_for :page_title, make_page_title("Download proposal documents") %>
+
+<h1 class="heading-large">Download all proposals</h1>
+<div class="sub-heading">
+  All <b><%= @downloads.count %></b> proposals are available for download.
+</div>
+<div class="grid-row">
+  <div class="column-third">
+    <h1 class="heading-medium">All downloads</h1>
+  </div>
+  <div class="column-two-thirds project-downloads">
+    <section class="projects-download-link">
+      <div class="attachment">
+        <div class="attachment-thumb">
+          <%= link_to image_tag("pafs_core/pub-cover-spreadsheet.png"), pafs_core.proposals_downloads_path, class: "thumbnail" %>
+        </div>
+        <div class="attachment-details">
+          <%= link_to "Proposal (Excel document)", pafs_core.proposals_downloads_path, class: "font-medium" %>
+          <p class="font-xsmall">MS Excel Spreadsheet</p>
+          <p class="font-xsmall">There are <%= @downloads.count %> proposals</p>
+          <p class="font-xsmall">
+            This is formatted in the same way as the old spreadsheet, for convenience.
+          </p>
+        </div>
+      </div>
+    </section>
+    <section class="projects-download-link">
+      <div class="attachment">
+        <div class="attachment-thumb">
+          <%= link_to image_tag("pafs_core/pub-cover-shapefile.png"), pafs_core.benefit_areas_downloads_path, class: "thumbnail" %>
+        </div>
+        <div class="attachment-details">
+          <%= link_to "Project benefit area files (zip file)", pafs_core.benefit_areas_downloads_path, class: "font-medium" %>
+          <p class="font-xsmall">
+            Compressed folder containing shapefiles for all <%= @downloads.shapefile_count %> proposals (zip file)
+          </p>
+          <p class="font-xsmall">
+            <%= @downloads.shapefile_count %> proposals have benefit area files
+          </p>
+        </div>
+      </div>
+    </section>
+    <% if @downloads.urgency_count.positive? %>
+      <section class="projects-download-link">
+        <div class="attachment">
+          <div class="attachment-thumb">
+            <%= link_to image_tag("pafs_core/pub-cover-doc.png"), pafs_core.moderations_downloads_path, class: "thumbnail" %>
+          </div>
+          <div class="attachment-details">
+            <%= link_to "Urgency moderation evidence", pafs_core.moderations_downloads_path, class: "font-medium" %>
+            <p class="font-xsmall">
+              Compressed folder containing urgency moderation evidence for <%= @downloads.urgency_count %> proposals (zip file)
+            </p>
+            <p class="font-xsmall">
+              <%= @downloads.urgency_count %> proposals have urgency moderation evidence
+            </p>
+          </div>
+        </div>
+      </section>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pafs_core/downloads/index.html.erb
+++ b/app/views/pafs_core/downloads/index.html.erb
@@ -17,9 +17,6 @@
           <p class="font-xsmall">
             This is formatted in the same way as the old spreadsheet, for convenience.
           </p>
-          <p class="font-xsmall">
-            Also available as <%= link_to "Comma Separated Values file", pafs_core.proposal_downloads_path(@project, format: :csv) %>
-          </p>
         </div>
       </div>
     </section>

--- a/app/views/pafs_core/projects/index.html.erb
+++ b/app/views/pafs_core/projects/index.html.erb
@@ -2,7 +2,7 @@
 <div id="dashboard">
   <h1 class="heading-large">Your proposals</h1>
 
-  <% if !pso_user? %>
+  <% if rma_user? %>
       <div class="grid-row">
         <div class="column-two-thirds">
           <div class="panel panel-indent panel-border-narrow panel-border-short">
@@ -12,9 +12,15 @@
       </div>
   <% end %>
 
-  <div class="create-new-project">
-    <%= link_to t('create_a_new_project_label'), pafs_core.new_bootstrap_path, class: "button" %>
-  </div>
+  <% if ea_user? %>
+    <div class="download-all-proposals-link">
+      <%= link_to t('download_all_proposals_label'), pafs_core.all_downloads_path %>
+    </div>
+  <% else %>
+    <div class="create-new-project">
+      <%= link_to t('create_a_new_project_label'), pafs_core.new_bootstrap_path, class: "button" %>
+    </div>
+  <% end %>
 
   <section>
     <table class="dashboard">
@@ -37,7 +43,11 @@
           <%= link_to "Last updated", pafs_core.projects_path(sort_col: "updated_at", sort_order: sort_properties_for_col[:next_sort_order]), class: "sortable-link" %>
           <span class="sortable-arrow"><%= raw(sort_properties_for_col[:curr_arrow]) %></span>
         </th>
-        <th scope="col">Status</th>
+
+        <% unless ea_user? %>
+          <th scope="col">Status</th>
+        <% end %>
+
         <% if pso_user? %>
           <th scope="col">In current programme</th>
         <% end %>
@@ -50,7 +60,9 @@
             <td><%= project.name %></td>
             <td><%= project.owner.name unless project.owner.blank? %></td>
             <td><%= l(project.updated_at) %></td>
-            <td><%= status_label_for(project.submission_state.current_state) %></td>
+            <% unless ea_user? %>
+              <td><%= status_label_for(project.submission_state.current_state) %></td>
+            <% end %>
             <% if pso_user? %>
               <td><%= project.consented? ? "Y" : "N" %></td>
             <% end %>

--- a/app/views/pafs_core/projects/show.html.erb
+++ b/app/views/pafs_core/projects/show.html.erb
@@ -7,7 +7,7 @@
       <div class="column-one-half">
         <h1 class="heading-large">Proposal overview</h1>
       </div>
-      <% if pso_user? && (@project.submitted? || @project.completed?) %>
+      <% if ea_user? || (pso_user? && (@project.submitted? || @project.completed?)) %>
         <div class="column-one-half">
           <div class="project-documents-download-link">
             <%= link_to "Download proposal documents", pafs_core.downloads_path(@project) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,14 @@ PafsCore::Engine.routes.draw do
   resources :projects do
     collection do
       get :pipeline
+      resources :downloads do
+        collection do
+          get :all
+          get :proposals
+          get :benefit_areas
+          get :moderations
+        end
+      end
     end
     member do
       resources :downloads, only: :index do

--- a/lib/pafs_core/files.rb
+++ b/lib/pafs_core/files.rb
@@ -22,6 +22,11 @@ module PafsCore
       builder.send("generate_#{format}", project)
     end
 
+    def generate_multi_fcerm1(projects, format)
+      builder = PafsCore::SpreadsheetService.new
+      builder.send("generate_multi_#{format}", projects)
+    end
+
     # benefit area file
     def make_benefit_area_file_name(reference, original_filename)
       "#{ref_to_file_name(reference)}_benefit_area#{File.extname(original_filename)}"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 FactoryGirl.define do
+  sequence :email do |n|
+    "person#{n}@example.com"
+  end
+
   factory :user, class: PafsCore::User do
     first_name "Norville"
     last_name "Rogers"
-    email "shaggy@example.com"
+    email
   end
 end

--- a/spec/services/pafs_core/project_service_spec.rb
+++ b/spec/services/pafs_core/project_service_spec.rb
@@ -11,6 +11,36 @@ RSpec.describe PafsCore::ProjectService do
   end
   subject { PafsCore::ProjectService.new(@user) }
 
+  describe "#search" do
+    it "returns all projects for a given user" do
+      # Create 2 projects against the user
+      subject.create_project
+      subject.create_project
+
+      results = subject.search
+      expect(results.count).to eq(2)
+
+      results.each do |result|
+        expect(result.creator_id).to eq(@user.id)
+      end
+    end
+
+    it "returns all projects for a given user and state" do
+      # Create 2 projects against the user and set their states (projects don't
+      # get a default state)
+      draft_project = subject.create_project
+      draft_project.create_state(state: "draft")
+      submitted_project = subject.create_project
+      submitted_project.create_state(state: "submitted")
+
+      # Search for submitted projects for the user
+      results = subject.search(state: "submitted")
+
+      expect(results.count).to eq(1)
+      expect(results.first.status).to eq(:submitted)
+    end
+  end
+
   describe "#new_project" do
     it "builds a new project model without saving to the database" do
       p = nil

--- a/spec/services/pafs_core/spreadsheet_service_spec.rb
+++ b/spec/services/pafs_core/spreadsheet_service_spec.rb
@@ -32,4 +32,23 @@ RSpec.describe PafsCore::SpreadsheetService do
       expect generated_xlsx == file
     end
   end
+
+  describe "#generate_multi_xlsx" do
+    it "should generate an xlsx file with a row for each project" do
+      # The area factory :country with trait :with_full_hierarchy_and_projects
+      # creates a hierarchy and 5 projects which is what we need for our test,
+      # but it doesn't create any users along the way. The ProjectService, and
+      # particularly its search() method are dependent on the projects being
+      # linked to the user, hence we create one here and attach it to the
+      # projects via a UserArea record.
+      rma_user = FactoryGirl.create(:user)
+      rma_area = PafsCore::Area.rma_areas.last
+      FactoryGirl.create(:user_area, user_id: rma_user.id, area_id: rma_area.id)
+
+      ps = PafsCore::ProjectService.new(rma_user)
+
+      puts "Search result count = #{ps.search.count}"
+      generated_xlsx = subject.generate_multi_xlsx(ps.search)
+    end
+  end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-297

This is the first step in offering users the ability to export all projects with a given status into a FCERM1 csv or spreadsheet. This change focuses on the back end, and expanding the exist functionality to

- search for all projects matching a given status for a user
- depending on user type this could encompass multiple areas
- export those projects into a csv or xlsx file using the FCERM1 format

Users of the service have expressed that they still wish to be able to work with project data in spreadsheets as they currently do, but currently the functionality in the system only allows for the export of one project per file.

The functionality this change will add will be linked to changes in the UI in the future, that will allow users to access the new feature.