### PR TITLE
Add google analytics content 2 Content Sec. Policy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       rails (~> 4.2.7.1)
       roo (~> 2.4.0)
       rubyXL
+      secure_headers (~> 3.6)
 
 GEM
   remote: https://rubygems.org/
@@ -59,13 +60,13 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.4)
-    aws-sdk (2.7.0)
-      aws-sdk-resources (= 2.7.0)
-    aws-sdk-core (2.7.0)
+    aws-sdk (2.8.7)
+      aws-sdk-resources (= 2.8.7)
+    aws-sdk-core (2.8.7)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.7.0)
-      aws-sdk-core (= 2.7.0)
+    aws-sdk-resources (2.8.7)
+      aws-sdk-core (= 2.8.7)
     aws-sigv4 (1.0.0)
     bstard (0.2.4)
     builder (3.2.3)
@@ -83,7 +84,7 @@ GEM
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
-    concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.2)
@@ -165,7 +166,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.5)
-    rack-cors (0.4.0)
+    rack-cors (0.4.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -220,11 +221,13 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubyXL (3.3.22)
+    rubyXL (3.3.23)
       nokogiri (>= 1.4.4)
       rubyzip (>= 1.1.6)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
+    secure_headers (3.6.2)
+      useragent
     shellany (0.0.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -245,6 +248,7 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    useragent (0.16.8)
     vcr (3.0.3)
     webmock (1.24.6)
       addressable (>= 2.3.6)
@@ -277,4 +281,4 @@ DEPENDENCIES
   webmock (~> 1.24)
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/app/controllers/pafs_core/application_controller.rb
+++ b/app/controllers/pafs_core/application_controller.rb
@@ -8,7 +8,7 @@ module PafsCore
 
     protect_from_forgery with: :exception
 
-    before_action :custom_headers
+    before_action :cache_busting
 
     rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
 
@@ -16,10 +16,6 @@ module PafsCore
 
     def raise_not_found
       raise ActionController::RoutingError.new("Not Found")
-    end
-
-    def custom_headers
-      response_headers!(response)
     end
 
     def handle_invalid_authenticity_token(exception)

--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -1,0 +1,56 @@
+require 'secure_headers'
+
+# Added in response to initial PEN test requiring we specify a
+# Content-Security-Policy. A CSP is
+# > delivered via a HTTP response header, much like HSTS, and defines
+# > approved sources of content that the browser may load. It can be an
+# > effective countermeasure to Cross Site Scripting (XSS) attacks and is
+# > also widely supported and usually easily deployed.
+# https://scotthelme.co.uk/content-security-policy-an-introduction/
+#
+# See the following for reference on CSP
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+#
+# See the following for reference on secure_headers and its configuration
+# https://github.com/twitter/secureheaders#configuration
+SecureHeaders::Configuration.default do |config|
+  # Specifically here we are saying
+  # - scripts can only come from the service or Google, however we permit
+  #   unsafe-inlinescripts (Google to support analytics)
+  # - images can only come from the service and Google (GA because it sends
+  #   the data to the Analytics server via a list of parameters attached to
+  #   a single-pixel image request)
+  # - fonts can only come from the service, or via the data: scheme
+  # - send any violation reports to a service we have setup for CSP
+  # - for all other items their soiurce must be the service (default-src)
+  #
+  # The following were used for reference
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
+  config.csp = {
+    default_src: %w('self'),
+    font_src: %w('self' data:),
+    img_src: %w('self' www.google-analytics.com),
+    object_src: %w('self'),
+    script_src: %w('self' 'unsafe-inline' www.googletagmanager.com www.google-analytics.com),
+    style_src: %w('self'),
+    report_uri: %w(https://environmentagency.report-uri.io/r/default/csp/enforce)
+  }
+
+  # TODO: These have been set to match the headers we were currently using at
+  # the time of implementing securer headers. We should review if they match
+  # match secure headers defaults, which give a good level security
+  config.x_content_type_options = "nosniff"
+  config.x_frame_options = "SAMEORIGIN"
+  config.x_xss_protection = "1; mode=block"
+
+  # TODO: If no values were passed in Secure headers would set these to its
+  # defaults. The issue was at time of implementing we were not using these
+  # headers, and felt that setting them was outside the scope of adding a
+  # Content-Security-Policy header. We need to come back to them though and
+  # check if there would be any issues using Secure Headers defaults, which
+  # would make the site more secure.
+  config.hsts = SecureHeaders::OPT_OUT # Strict-Transport-Security
+  config.x_download_options = SecureHeaders::OPT_OUT
+  config.x_permitted_cross_domain_policies = SecureHeaders::OPT_OUT
+end

--- a/lib/pafs_core/custom_headers.rb
+++ b/lib/pafs_core/custom_headers.rb
@@ -2,39 +2,24 @@
 # frozen_string_literal: true
 
 module PafsCore
+  # Use to set any custom, non-security related response headers. Intended to be
+  # used in Controllers and called using a before_action
+  #
+  # class ApplicationController < ActionController::Base
+  #   include PafsCore::CustomHeaders
+  #   before_action :cache_busting
+  # end
+  #
+  # Any security related headers should be specified in
+  # `config/initializers/secure_headers.rb`
   module CustomHeaders
 
-    # Intended to be used in ApplicationController's, specifically from a
-    # before_action() in order to update the response headers.
-    def response_headers!(response)
+    def cache_busting
       # Cache buster, specifically we don't want the client to cache any
       # responses from the service
       response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate, private"
       response.headers["Pragma"] = "no-cache"
       response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
-
-      # Added in response to initial PEN test. A Content-Security-Policy
-      # > is delivered via a HTTP response header, much like HSTS, and defines
-      # > approved sources of content that the browser may load. It can be an
-      # > effective countermeasure to Cross Site Scripting (XSS) attacks and is
-      # > also widely supported and usually easily deployed.
-      # https://scotthelme.co.uk/content-security-policy-an-introduction/
-      #
-      # Specifically here we are saying
-      # - scripts can only come from the service, however we permit
-      #   unsafe-inlinescripts
-      # - fonts can only come from the service, or via the data: scheme
-      # - send any violation reports to a service we have setup for CSP
-      # - for all other items their soiurce must be the service (default-src)
-      #
-      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
-      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/font-src
-      # https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-      response
-        .headers["Content-Security-Policy"] = "default-src 'self'; "\
-                                              "script-src 'self' 'unsafe-inline'; "\
-                                              "font-src 'self' data:; "\
-                                              "report-uri https://environmentagency.report-uri.io/r/default/csp/enforce"
     end
 
   end

--- a/pafs_core.gemspec
+++ b/pafs_core.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bstard"
   s.add_dependency "faraday"
   s.add_dependency "kaminari"
+  s.add_dependency "secure_headers", "~> 3.6"
   s.add_development_dependency "pg"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "factory_girl_rails", "~> 4.0"

--- a/spec/controllers/pafs_core/application_controller_spec.rb
+++ b/spec/controllers/pafs_core/application_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe PafsCore::ApplicationController, type: :controller do
+  controller do
+    def index
+      render text: "Hello World"
+    end
+  end
+
+  describe "response" do
+    it "has cache busting headers in the response" do
+      get :index
+
+      expect(response.headers["Cache-Control"]).to eq "no-cache, no-store, max-age=0, must-revalidate, private"
+      expect(response.headers["Pragma"]).to eq "no-cache"
+      expect(response.headers["Expires"]).to eq "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+
+    # TODO: As core holds the secure_headers gem and its config, it would be
+    # nice to confirm that all responses from it include our
+    # Content-Security-Policy however currently we can't figure out how to get
+    # secure_headers to kick in via a test.
+    it "has Content-Security-Policy header in the response" do
+      skip "Cannot ascertain how to invoke secure_headers from pafs_core"
+      get :index
+
+      expect(response.headers["Content-Security-Policy"]).to eq "boo"
+    end
+  end
+end

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,4 +1,6 @@
 # This file is used by Rack-based servers to start the application.
+require "secure_headers"
+use SecureHeaders::Middleware
 
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application

--- a/spec/lib/pafs_core/custom_headers_spec.rb
+++ b/spec/lib/pafs_core/custom_headers_spec.rb
@@ -3,38 +3,28 @@
 require "rails_helper"
 
 RSpec.describe PafsCore::CustomHeaders do
-  before(:each) do
+  describe "#cache_busting" do
+    let(:my_mock) { MockObjectWithResponse.new }
+
+    it "sets the necessary headers to prevent caching in the browser" do
+      my_mock.cache_busting
+
+      expect(my_mock.response.headers["Cache-Control"]).to eq "no-cache, no-store, max-age=0, must-revalidate, private"
+      expect(my_mock.response.headers["Pragma"]).to eq "no-cache"
+      expect(my_mock.response.headers["Expires"]).to eq "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
+  end
+end
+
+# To ensure custom headers is working at its most basic, we include it in a
+# PORO that has an attribute called response. This mimics a controller and its
+# response attribute
+class MockObjectWithResponse
+  include PafsCore::CustomHeaders
+  attr_reader :response
+
+  def initialize
     @response = OpenStruct.new
     @response.headers = {}
-    @response
-  end
-
-  describe "#response_headers!" do
-    let(:dummy_controller) do
-      Class.new { include PafsCore::CustomHeaders }.new
-    end
-
-    context "Cache busting" do
-      it "sets the necessary headers to prevent caching in the browser" do
-        dummy_controller.response_headers!(@response)
-
-        expect(@response.headers["Cache-Control"]).to eq "no-cache, no-store, max-age=0, must-revalidate, private"
-        expect(@response.headers["Pragma"]).to eq "no-cache"
-        expect(@response.headers["Expires"]).to eq "Fri, 01 Jan 1990 00:00:00 GMT"
-      end
-    end
-
-    context "Content security policy" do
-      it "sets the necessary headers to ensure all content comes from the site's origin" do
-        dummy_controller.response_headers!(@response)
-
-        expect(@response.headers["Content-Security-Policy"]).to eq(
-          "default-src 'self'; "\
-          "script-src 'self' 'unsafe-inline'; "\
-          "font-src 'self' data:; "\
-          "report-uri https://environmentagency.report-uri.io/r/default/csp/enforce"
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-286

PR #128 was part of adding a Content-Security-Policy to the response header for all responses. However it was spotted that the layout in the **pafs-user** app has a section related to Google Analytics which is only added if the env var `GOOGLE_ANALYTICS_ID` is present.

We therefore need to update the policy to include these sources from Google, as `GOOGLE_ANALYTICS_ID` will be present in the production environment.