### PR TITLE
Update links in confirm pages to use real links

### DIFF
--- a/app/views/pafs_core/projects/confirm_area.html.erb
+++ b/app/views/pafs_core/projects/confirm_area.html.erb
@@ -18,7 +18,7 @@
         <%= link_to "Return to your proposals", projects_path, class: "button", role: "button" %>
       </div>
       <div class="form-group">
-        <%= link_to "What did you think of this service?", "#" %> (takes 30 seconds)
+        <%= link_to "What did you think of this service?", PafsCore.config.complete_page_feedback_uri, target: '_blank' %> (takes 30 seconds)
       </div>
     </div>
   </div>

--- a/app/views/pafs_core/projects/confirm_rma.html.erb
+++ b/app/views/pafs_core/projects/confirm_rma.html.erb
@@ -18,7 +18,7 @@
       </div>
 
       <div class="form-group">
-        <%= link_to "What did you think of this service?", "#" %> (takes 30 seconds)
+        <%= link_to "What did you think of this service?", PafsCore.config.complete_page_feedback_uri, target: '_blank' %> (takes 30 seconds)
       </div>
     </div>
   </div>


### PR DESCRIPTION
The links in the confirm pages (essentially the done pages for PAFS) were set to just point back on themselves. This change updates the links to point to the services GDS feedback page, pulling the value from config and ensuring the page opens in a new tab.