### PR TITLE
Update RFCC codes to include test areas

### DIFF
--- a/app/models/pafs_core/project.rb
+++ b/app/models/pafs_core/project.rb
@@ -5,7 +5,7 @@ require "bstard"
 module PafsCore
   class Project < ActiveRecord::Base
     validates :reference_number, presence: true, uniqueness: { scope: :version }
-    validates :reference_number, format: { with: /\A(AC|AE|AN|NO|NW|SN|SO|SW|TH|TR|WX|YO)C501E\/\d{3}A\/\d{3}A\z/,
+    validates :reference_number, format: { with: /\A(AC|AE|AN|NO|NW|SN|SO|SW|TH|TR|TS|WX|YO)C501E\/\d{3}A\/\d{3}A\z/,
                                            message: "has an invalid format" }
     validates :version, presence: true
 

--- a/lib/pafs_core/rfcc_codes.rb
+++ b/lib/pafs_core/rfcc_codes.rb
@@ -1,7 +1,7 @@
 # Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
 module PafsCore
-  RFCC_CODES = %w[ AC AE AN NO NW SN SO SW TH TR WX YO ].freeze
+  RFCC_CODES = %w[ AC AE AN NO NW SN SO SW TH TR TS WX YO ].freeze
 
   # map RFCC codes to names
 
@@ -16,6 +16,7 @@ module PafsCore
     "SW" => "Southwest",
     "TH" => "Thames",
     "TR" => "Trent",
+    "TS" => "Test",
     "WX" => "Wessex",
     "YO" => "Yorkshire",
   }.freeze
@@ -54,6 +55,7 @@ module PafsCore
     "PSO Somerset"                                        => "WX",
     "PSO South West London & Mole"                        => "TH",
     "PSO South Yorkshire"                                 => "YO",
+    "PSO Test Area"                                       => "TS",
     "PSO Tyne and Wear & Northumberland"                  => "NO",
     "PSO Warwickshire, Birmingham, Solihull & Coventry"   => "SN",
     "PSO Welland & Nene"                                  => "AN",

--- a/spec/services/pafs_core/project_service_spec.rb
+++ b/spec/services/pafs_core/project_service_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe PafsCore::ProjectService do
     it "returns a reference number in the correct format" do
       PafsCore::RFCC_CODES.each do |rfcc_code|
         ref = described_class.generate_reference_number(rfcc_code)
-        expect(ref).to match /\A(AC|AE|AN|NO|NW|SN|SO|SW|TH|TR|WX|YO)C501E\/\d{3}A\/\d{3}A\z/
+        expect(ref).to match /\A(AC|AE|AN|NO|NW|SN|SO|SW|TH|TR|TS|WX|YO)C501E\/\d{3}A\/\d{3}A\z/
       end
     end
   end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PM-151

As part of finalising the areas.csv file which will be used to seed the database (see https://github.com/DEFRA/pafs-user/pull/116) we added in some test areas. This will allow the team to investigate issues, or demonstrate functionality without adding dummy data to real areas.

However we had not considered that we have RFCC codes which are used to determine the project reference number, that did not recognise these new test areas.

This change fixes that by adding a new RFC code (TS) which projects linked to test areas will use, and ensuring an validation will work with the new RFCC code.