### PR TITLE
Added consented flag to project

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -15,6 +15,7 @@
 #
 
 gemfile: '.overcommit_gems.rb'
+verify_signatures: false
 
 PreCommit:
   Brakeman:

--- a/.overcommit_gems.rb.lock
+++ b/.overcommit_gems.rb.lock
@@ -94,5 +94,8 @@ DEPENDENCIES
   rubocop
   scss_lint
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.14.4

--- a/app/decorators/pafs_core/imported_project_decorator.rb
+++ b/app/decorators/pafs_core/imported_project_decorator.rb
@@ -51,7 +51,7 @@ module PafsCore
     end
 
     def consented=(value)
-      # project.consented = (value == "Y" | value == "y")
+      project.consented = (value == "Y" || value == "y")
     end
 
     def grid_reference=(value)

--- a/app/models/pafs_core/project.rb
+++ b/app/models/pafs_core/project.rb
@@ -8,7 +8,7 @@ module PafsCore
     # broaden validation to cope with initial bulk import of existing projects
     # with subtly non-standard formatting
     validates :reference_number,
-      format: { with: /\A(AC|AE|AN|NO|NW|SN|SO|SW|TH|TR|WX|YO)[A-Z]\d{3,4}[A-Z]\/\d{3}A\/\d{3,4}[A-Z]\z/,
+      format: { with: /\A(AC|AE|AN|NO|NW|SN|SO|SW|TH|TR|WX|YO)[A-Z]\d{3,4}[A-Z]\/\d{3}[A-Z]\/\d{3,4}[A-Z]\z/,
                 message: "has an invalid format" }
 
     validates :version, presence: true

--- a/app/presenters/pafs_core/spreadsheet_presenter.rb
+++ b/app/presenters/pafs_core/spreadsheet_presenter.rb
@@ -64,8 +64,7 @@ module PafsCore
     end
 
     def consented
-      # FIXME: this flag hasn't been added to the project yet
-      "N"
+      y_or_n project.consented?
     end
 
     def grid_reference

--- a/app/services/pafs_core/program_upload_service.rb
+++ b/app/services/pafs_core/program_upload_service.rb
@@ -45,6 +45,9 @@ module PafsCore
         xlsx = fetch_workbook(upload_record.filename)
         row_count = 0
 
+        # clear all consented flags
+        PafsCore::Project.update_all(consented: false)
+
         # Roo has an odd offset so we have to take 2 off our zero-based
         # FIRST_DATA_ROW value
         xlsx.each_row_streaming(pad_cells: true,

--- a/db/migrate/20170328091527_add_consented_flag_to_project.rb
+++ b/db/migrate/20170328091527_add_consented_flag_to_project.rb
@@ -1,0 +1,5 @@
+class AddConsentedFlagToProject < ActiveRecord::Migration
+  def change
+    add_column :pafs_core_projects, :consented, :boolean, null: false, default: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170326095458) do
+ActiveRecord::Schema.define(version: 20170328091527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -240,6 +240,7 @@ ActiveRecord::Schema.define(version: 20170326095458) do
     t.datetime "urgency_details_updated_at"
     t.string   "grid_reference"
     t.boolean  "reservoir_flooding"
+    t.boolean  "consented",                                        default: false, null: false
   end
 
   add_index "pafs_core_projects", ["reference_number", "version"], name: "index_pafs_core_projects_on_reference_number_and_version", unique: true, using: :btree


### PR DESCRIPTION
Added consented flag to PafsCore::Project and updated decorator and presented to use this value.
This enables us to indicate whether a proposal has been consented for funding in the annual programme refresh.