### PR TITLE
Added reset consented flag to programme import

### DIFF
--- a/db/migrate/20170424093915_add_reset_consented_flag_to_program_upload.rb
+++ b/db/migrate/20170424093915_add_reset_consented_flag_to_program_upload.rb
@@ -1,0 +1,5 @@
+class AddResetConsentedFlagToProgramUpload < ActiveRecord::Migration
+  def change
+    add_column :pafs_core_program_uploads, :reset_consented_flag, :boolean, null: false, default: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170328091527) do
+ActiveRecord::Schema.define(version: 20170424093915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,11 +142,12 @@ ActiveRecord::Schema.define(version: 20170328091527) do
   add_index "pafs_core_program_upload_items", ["program_upload_id"], name: "idx_program_upload_items", using: :btree
 
   create_table "pafs_core_program_uploads", force: :cascade do |t|
-    t.string   "filename",                          null: false
-    t.integer  "number_of_records",                 null: false
+    t.string   "filename",                             null: false
+    t.integer  "number_of_records",                    null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "status",            default: "new"
+    t.string   "status",               default: "new"
+    t.boolean  "reset_consented_flag", default: false, null: false
   end
 
   add_index "pafs_core_program_uploads", ["status"], name: "pafs_core_upload_status", using: :btree


### PR DESCRIPTION
Added ability to import partial programme import or data fixes through the programme refresh spreadsheet import.  This is to facilitate fixes to the project area, for example, without requiring console access and a dev.