### PR TITLE
Wrapped jobs with AR connection pool block

### DIFF
--- a/app/controllers/pafs_core/projects_controller.rb
+++ b/app/controllers/pafs_core/projects_controller.rb
@@ -40,7 +40,7 @@ class PafsCore::ProjectsController < PafsCore::ApplicationController
 
     # send files to asite
     # asite.submit_project(@project)
-    PafsCore::AsiteSubmissionJob.perform_later(@project)
+    PafsCore::AsiteSubmissionJob.perform_later(@project.id)
 
     redirect_to pafs_core.confirm_project_path(@project)
   end

--- a/app/jobs/pafs_core/account_request_cleanup_job.rb
+++ b/app/jobs/pafs_core/account_request_cleanup_job.rb
@@ -4,11 +4,13 @@ module PafsCore
     queue_as :default
 
     def perform
-      # remove account requests older than 30 days
-      PafsCore::AccountRequest.expired.each(&:destroy)
-      # remove User accounts which were invited 30 days ago or more
-      # and the invite has not yet been accepted
-      User.expired_invite.each(&:destroy)
+      ActiveRecord::Base.connection_pool.with_connection do
+        # remove account requests older than 30 days
+        PafsCore::AccountRequest.expired.each(&:destroy)
+        # remove User accounts which were invited 30 days ago or more
+        # and the invite has not yet been accepted
+        User.expired_invite.each(&:destroy)
+      end
     end
   end
 end

--- a/app/jobs/pafs_core/asite_submission_job.rb
+++ b/app/jobs/pafs_core/asite_submission_job.rb
@@ -3,8 +3,10 @@ module PafsCore
   class AsiteSubmissionJob < ActiveJob::Base
     queue_as :default
 
-    def perform(project)
-      PafsCore::AsiteService.new.submit_project(project)
+    def perform(project_id)
+      ActiveRecord::Base.connection_pool.with_connection do
+        PafsCore::AsiteService.new.submit_project(PafsCore::Project.find(project_id))
+      end
     end
   end
 end

--- a/app/jobs/pafs_core/generate_area_programme_job.rb
+++ b/app/jobs/pafs_core/generate_area_programme_job.rb
@@ -5,8 +5,10 @@ module PafsCore
 
     include PafsCore::Files, PafsCore::FileStorage
 
-    def perform(user)
-      PafsCore::AreaDownloadService.new(user).generate_area_programme
+    def perform(user_id)
+      ActiveRecord::Base.connection_pool.with_connection do
+        PafsCore::AreaDownloadService.new(PafsCore::User.find(user_id)).generate_area_programme
+      end
     end
   end
 end

--- a/app/jobs/pafs_core/import_program_refresh_job.rb
+++ b/app/jobs/pafs_core/import_program_refresh_job.rb
@@ -3,9 +3,11 @@ module PafsCore
   class ImportProgramRefreshJob < ActiveJob::Base
     queue_as :default
 
-    def perform(upload_record)
-      pup = PafsCore::ProgramUploadService.new
-      pup.process_spreadsheet(upload_record)
+    def perform(upload_record_id)
+      ActiveRecord::Base.connection_pool.with_connection do
+        pup = PafsCore::ProgramUploadService.new
+        pup.process_spreadsheet(pup.find(upload_record_id))
+      end
     end
   end
 end

--- a/app/services/pafs_core/area_download_service.rb
+++ b/app/services/pafs_core/area_download_service.rb
@@ -24,7 +24,7 @@ module PafsCore
         info.save!
 
         # kick off background job
-        PafsCore::GenerateAreaProgrammeJob.perform_later user
+        PafsCore::GenerateAreaProgrammeJob.perform_later user.id
       end
     end
 


### PR DESCRIPTION
Issue reported where background jobs experience failures obtaining db connections, so wrapping the job code with `ActiveRecord::Base.connection_pool.with_connection` blocks to ensure they get and return a connection to the pool.