### PR TITLE
[PK-962] validate Partnership Funding Calculator

### DIFF
--- a/app/steps/pafs_core/funding_calculator_step.rb
+++ b/app/steps/pafs_core/funding_calculator_step.rb
@@ -79,7 +79,7 @@ module PafsCore
     end
 
     def validate_calculator_version
-      if self.uploaded_file
+      if virus_info.nil? && self.uploaded_file
         sheet = ::Roo::Excelx.new(self.uploaded_file)
 
         unless sheet.cell('B', 3) == 'Version 8 January 2014'

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -175,7 +175,6 @@ FactoryGirl.define do
 
     factory :funding_calculator_step, class: PafsCore::FundingCalculatorStep do
       funding_calculator_file_name  "pf_calc.xls"
-      uploaded_file                 File.join(Rails.root, '..', 'fixtures', 'calculator.xlsx')
     end
 
     factory :funding_calculator_summary_step, class: PafsCore::FundingCalculatorSummaryStep do

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -174,7 +174,8 @@ FactoryGirl.define do
     end
 
     factory :funding_calculator_step, class: PafsCore::FundingCalculatorStep do
-      funding_calculator_file_name "pf_calc.xls"
+      funding_calculator_file_name  "pf_calc.xls"
+      uploaded_file                 File.join(Rails.root, '..', 'fixtures', 'calculator.xlsx')
     end
 
     factory :funding_calculator_summary_step, class: PafsCore::FundingCalculatorSummaryStep do

--- a/spec/steps/pafs_core/funding_calculator_step_spec.rb
+++ b/spec/steps/pafs_core/funding_calculator_step_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PafsCore::FundingCalculatorStep, type: :model do
         to receive(:uploaded_file).
         and_return(file_path)
 
-      allow(Roo::Excelx).
+      expect(Roo::Excelx).
         to receive(:new).
         and_return(double(:sheet, cell: 'Version 5'))
 
@@ -40,6 +40,19 @@ RSpec.describe PafsCore::FundingCalculatorStep, type: :model do
 
       expect(subject.errors[:base]).
         to include 'The partnership funding calculator file used is the wrong version. The file used must be version 8. Download the correct partnership funding calculator'
+    end
+
+    context 'virus found' do
+      it 'does not validate the calculator version' do
+        allow(subject).
+          to receive(:virus_info).
+          and_return('Some virus')
+
+        expect(Roo::Excelx).
+          not_to receive(:new)
+
+        subject.valid?
+      end
     end
   end
 

--- a/spec/steps/pafs_core/funding_calculator_step_spec.rb
+++ b/spec/steps/pafs_core/funding_calculator_step_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe PafsCore::FundingCalculatorStep, type: :model do
         to receive(:new).
         and_return(double(:sheet, cell: 'Version 5'))
 
-      expect(subject).not_to be_valid
+      subject.valid?
+
       expect(subject.errors[:base]).
         to include 'The partnership funding calculator file used is the wrong version. The file used must be version 8. Download the correct partnership funding calculator'
     end

--- a/spec/steps/pafs_core/funding_calculator_step_spec.rb
+++ b/spec/steps/pafs_core/funding_calculator_step_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe PafsCore::FundingCalculatorStep, type: :model do
   describe "attributes" do
     subject { FactoryGirl.build(:funding_calculator_step) }
 
+    let(:file_path) { File.join(Rails.root, '..', 'fixtures', 'calculator.xlsl') }
+
     it_behaves_like "a project step"
 
     it "validates that a file has been selected" do
@@ -23,6 +25,20 @@ RSpec.describe PafsCore::FundingCalculatorStep, type: :model do
       expect(subject.valid?).to eq false
       expect(subject.errors[:base]).
         to include "The file was rejected because it may contain a virus. Check the file and try again"
+    end
+
+    it 'validates the calculator version' do
+      allow(subject).
+        to receive(:uploaded_file).
+        and_return(file_path)
+
+      allow(Roo::Excelx).
+        to receive(:new).
+        and_return(double(:sheet, cell: 'Version 5'))
+
+      expect(subject).not_to be_valid
+      expect(subject.errors[:base]).
+        to include 'The partnership funding calculator file used is the wrong version. The file used must be version 8. Download the correct partnership funding calculator'
     end
   end
 


### PR DESCRIPTION
Resolves the issue of users uploading outdated PF Calculators.

We now check the calculator version, after we've done a virus check, to make sure that the user has the latest version.

If they do not, we return false and display an error message.

https://eaflood.atlassian.net/browse/PK-962