### PR TITLE
[PK-910] - 'Expected' Environment Agency sources

### DIFF
--- a/app/steps/pafs_core/other_ea_contributors_step.rb
+++ b/app/steps/pafs_core/other_ea_contributors_step.rb
@@ -6,7 +6,7 @@ module PafsCore
              to: :project
 
     validates :other_ea_contributor_names,
-      presence: { message: "^Tell us about the contributions from other Environment Agency functions or sources." }
+      presence: { message: "^Tell us about the expected contributions from other Environment Agency functions or sources." }
 
   private
     def step_params(params)

--- a/config/locales/steps.en.yml
+++ b/config/locales/steps.en.yml
@@ -78,7 +78,7 @@ en:
           heading: Who are the expected private sector contributors?
           example_text: "For example, a local business such as Llanmoor Development Company."
         other_ea_contributors:
-          heading: "What are the contributions from other Environment Agency sources?"
+          heading: "What are the expected contributions from other Environment Agency sources?"
           example_text: "These are Environment Agency functions or funding streams. For example, Water Framework Directive or Water Resources."
 # funding values
         funding_values:

--- a/spec/steps/pafs_core/other_ea_contributors_step_spec.rb
+++ b/spec/steps/pafs_core/other_ea_contributors_step_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PafsCore::OtherEaContributorsStep, type: :model do
       subject.other_ea_contributor_names = nil
       expect(subject.valid?).to be false
       expect(subject.errors.messages[:other_ea_contributor_names]).
-        to include "^Tell us about the contributions from other Environment Agency functions or sources."
+        to include "^Tell us about the expected contributions from other Environment Agency functions or sources."
     end
   end
 


### PR DESCRIPTION
Update copy to include the word 'expected' when determining the expected contributions from other EA functions or sources.