### PR TITLE
[PK-931] Amend service validation to allow projects that don't protect households

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_script:
   - psql -c 'create database pafs_core_dummy_test;' -U postgres
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
-  - bundle exec rake db:test:prepare
   - bundle exec rake spec
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
   - sudo apt-get install -y libffi-dev
   - git config --global user.name "Travis Test"
   - git config --global user.email travis@example.com
+  - psql -c 'create database pafs_core_dummy_test;' -U postgres
 script:
   - RAILS_ENV=test bundle exec rake db:migrate --trace
   - bundle exec rake db:test:prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ before_script:
   - git config --global user.name "Travis Test"
   - git config --global user.email travis@example.com
 script:
-  - >-
-    bundle exec rake spec
+  - RAILS_ENV=test bundle exec rake db:migrate --trace
+  - bundle exec rake db:test:prepare
+  - bundle exec rake spec
 
 services:
   - postgresql

--- a/app/steps/pafs_core/coastal_erosion_protection_outcomes_step.rb
+++ b/app/steps/pafs_core/coastal_erosion_protection_outcomes_step.rb
@@ -5,7 +5,10 @@ module PafsCore
     include PafsCore::Risks, PafsCore::Outcomes, PafsCore::FinancialYear
     delegate :project_type,
              :project_protects_households?,
+             :reduced_risk_of_households_for_coastal_erosion,
+             :reduced_risk_of_households_for_coastal_erosion=,
              to: :project
+
     validate :at_least_one_value, :values_make_sense, :sensible_number_of_houses
 
     def before_view(params)
@@ -40,8 +43,8 @@ module PafsCore
     def at_least_one_value
       errors.add(
         :base,
-        "In the applicable year(s), tell us how many households are at a reduced risk of coastal erosion (column A)."
-      ) if coastal_total_protected_households.zero?
+        "In the applicable year(s), tell us how many households are at a reduced risk of coastal erosion (column A), OR if this does not apply select the checkbox."
+      ) if coastal_total_protected_households.zero? and !project.reduced_risk_of_households_for_coastal_erosion?
     end
 
     private
@@ -80,7 +83,7 @@ module PafsCore
     def step_params(params)
       ActionController::Parameters.new(params)
                                   .require(:coastal_erosion_protection_outcomes_step)
-                                  .permit(coastal_erosion_protection_outcomes_attributes:
+                                  .permit(:reduced_risk_of_households_for_coastal_erosion, coastal_erosion_protection_outcomes_attributes:
                                     [
                                       :id,
                                       :financial_year,

--- a/app/steps/pafs_core/flood_protection_outcomes_step.rb
+++ b/app/steps/pafs_core/flood_protection_outcomes_step.rb
@@ -5,6 +5,8 @@ module PafsCore
     delegate :project_end_financial_year,
              :project_type,
              :project_protects_households?,
+             :reduced_risk_of_households_for_floods,
+             :reduced_risk_of_households_for_floods=,
              to: :project
 
     validate :at_least_one_value, :values_make_sense, :sensible_number_of_houses
@@ -43,9 +45,8 @@ module PafsCore
     def at_least_one_value
       errors.add(
         :base,
-        "In the applicable year(s), tell us how many households moved to a lower flood\
-        risk category (column A)."
-      ) if flooding_total_protected_households.zero?
+        "In the applicable year(s), tell us how many households moved to a lower flood risk category (column A), OR if this does not apply select the checkbox."
+      ) if flooding_total_protected_households.zero? and !project.reduced_risk_of_households_for_floods?
     end
 
     private
@@ -85,7 +86,7 @@ module PafsCore
     def step_params(params)
       ActionController::Parameters.new(params)
                                   .require(:flood_protection_outcomes_step)
-                                  .permit(flood_protection_outcomes_attributes:
+                                  .permit(:reduced_risk_of_households_for_floods, flood_protection_outcomes_attributes:
                                     [
                                       :id,
                                       :financial_year,

--- a/app/views/pafs_core/projects/steps/coastal_erosion_protection_outcomes.html.erb
+++ b/app/views/pafs_core/projects/steps/coastal_erosion_protection_outcomes.html.erb
@@ -9,6 +9,7 @@
           <%= f.form_group :base do %>
             <%= f.error_message(:base) %>
             <div class="scroll-horz">
+              <%= f.check_box :reduced_risk_of_households_for_coastal_erosion %>
               <table class="protection-outcomes-table hidden-totals">
                 <thead>
                   <tr>

--- a/app/views/pafs_core/projects/steps/flood_protection_outcomes.html.erb
+++ b/app/views/pafs_core/projects/steps/flood_protection_outcomes.html.erb
@@ -9,6 +9,7 @@
           <%= f.form_group :base do %>
             <%= f.error_message(:base) %>
             <div class="scroll-horz">
+              <%= f.check_box :reduced_risk_of_households_for_floods %>
               <table class="protection-outcomes-table hidden-totals">
                 <thead>
                   <tr>

--- a/config/locales/steps.en.yml
+++ b/config/locales/steps.en.yml
@@ -193,6 +193,7 @@ en:
         flood_protection_outcomes:
           heading: How many households affected by flooding is the project likely to benefit?
           lede: Don't include houses built or converted after 1 January 2012.
+          reduced_risk_of_households_for_floods_label: My project does not move any households to a lower flood risk category
           financial_year_label: Financial year (April to March)
           households_at_reduced_risk_label: How many households will move to a lower flood risk category?
           households_moved_from_very_significant_and_significant_to_moderate_or_low_label: Of the households in column A, how many will move out of the very significant or significant category to the moderate or low category?
@@ -210,6 +211,7 @@ en:
         coastal_erosion_protection_outcomes:
           heading: How many households affected coastal erosion is the project likely to benefit?
           lede: Don't include houses built or converted after 1 January 2012.
+          reduced_risk_of_households_for_coastal_erosion_label: My project does not reduce the risk of coastal erosion for any households
           financial_year_label: Financial year (April to March)
           households_at_reduced_risk_label: How many households will be at a reduced risk of coastal erosion?
           households_protected_from_loss_in_next_20_years_label: Of the households in column A, how many will be protected from loss within the next 20 years?

--- a/db/migrate/20180529124243_add_reduced_households_for_floods_and_coastal_erosion.rb
+++ b/db/migrate/20180529124243_add_reduced_households_for_floods_and_coastal_erosion.rb
@@ -1,0 +1,6 @@
+class AddReducedHouseholdsForFloodsAndCoastalErosion < ActiveRecord::Migration
+  def change
+    add_column :pafs_core_projects, :reduced_risk_of_households_for_floods,          :boolean, null: false, default: false
+    add_column :pafs_core_projects, :reduced_risk_of_households_for_coastal_erosion, :boolean, null: false, default: false
+  end
+end


### PR DESCRIPTION
Allow users to select whether their project moves any households into lower flood and coastal erosion risk.