### PR TITLE
[PK-970] Area programming staff download 'draft' status projects

### DIFF
--- a/app/services/pafs_core/project_navigator.rb
+++ b/app/services/pafs_core/project_navigator.rb
@@ -45,7 +45,7 @@ module PafsCore
     end
 
     def find_apt_projects
-      project_service.submitted_projects
+      project_service.downloadable_projects
     end
 
     def search(options = {})

--- a/app/services/pafs_core/project_service.rb
+++ b/app/services/pafs_core/project_service.rb
@@ -30,6 +30,12 @@ module PafsCore
         first!
     end
 
+    def downloadable_projects
+      PafsCore::Project.joins(:state).
+        joins(:area_projects).
+        merge(PafsCore::AreaProject.where(area_id: area_ids_for_user(user)))
+    end
+
     def submitted_projects
       PafsCore::Project.joins(:state).
         merge(PafsCore::State.submitted).


### PR DESCRIPTION
Allow users to download of proposals regardless of the project state