### PR TITLE
Update Engine to re-use factories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.10.0)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)

--- a/lib/pafs_core/engine.rb
+++ b/lib/pafs_core/engine.rb
@@ -10,5 +10,9 @@ module PafsCore
       g.assets false
       g.helper false
     end
+
+    initializer "pafs_core.factories", :after => "factory_girl.set_factory_paths" do
+      FactoryGirl.definition_file_paths << File.expand_path('../../../spec/factories', __FILE__) if defined?(FactoryGirl)
+    end
   end
 end

--- a/spec/factories/account_requests.rb
+++ b/spec/factories/account_requests.rb
@@ -2,11 +2,11 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :account_request, class: PafsCore::AccountRequest do
-    first_name "Peter"
-    last_name "Shilton"
-    email "pete@example.com"
-    organisation "Wessex Water"
-    job_title "Windmill Researcher"
-    telephone_number "0123456678"
+    first_name "Big"
+    last_name "Nev"
+    email "neville.southall@example.com"
+    organisation "Everton FC"
+    job_title "Pie Eater"
+    telephone_number "01234567890"
   end
 end


### PR DESCRIPTION
As part of https://eaflood.atlassian.net/browse/PK-1082 we are required to expose an API via `pafs-users`.

To achieve this we'll be re-using the factories supplied in this gem to setup the necessary test data.