### PR TITLE
Bugfix/resolve risk and household benefits issue

### DIFF
--- a/app/steps/pafs_core/flood_protection_outcomes_step.rb
+++ b/app/steps/pafs_core/flood_protection_outcomes_step.rb
@@ -29,7 +29,7 @@ module PafsCore
         end
       end.compact!
 
-      if values.include?(true)
+      if values.present? && values.include?(true)
         errors.add(
           :base,
           "In the applicable year(s), tell us how many households moved to a lower flood risk category (column A), OR if this does not apply select the checkbox."


### PR DESCRIPTION
WIP

Resolves: PK-1124 & PK-1121

Addresses issue with validating household benefit values.

This affects the programme import functionality along with the main service, when users attempt to input 0's and check the tick box.