### PR TITLE
Fix tests that now break as we're in a new tax year.

### DIFF
--- a/spec/controllers/pafs_core/projects_controller_spec.rb
+++ b/spec/controllers/pafs_core/projects_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe PafsCore::ProjectsController, type: :controller do
           {
             "financial_year_step": {
               "id": "4",
-              "project_end_financial_year": "2018"
+              "project_end_financial_year": Date.today.year
             },
             "commit": "Save and continue",
             "id": @project.to_param,

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     end
 
     factory :financial_year_step, class: PafsCore::FinancialYearStep do
-      project_end_financial_year 2018
+      project_end_financial_year Date.today.year
     end
 
     factory :financial_year_alternative_step, class: PafsCore::FinancialYearAlternativeStep do


### PR DESCRIPTION
Changes include using the current year as the financial year end,
meaning that we won't have to keep changing this in the future.