### PR TITLE
[PM-384] Refactor project state and add factory

### DIFF
--- a/app/models/pafs_core/state.rb
+++ b/app/models/pafs_core/state.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 module PafsCore
   class State < ActiveRecord::Base
+    VALID_STATES = %w[draft completed submitted updatable updated archived finished].freeze
+
     belongs_to :project, inverse_of: :state
-    validates :state, inclusion: { in: %w[draft completed submitted updatable updated archived finished] }
+    validates :state, inclusion: { in: VALID_STATES }
 
     def self.submitted
       where(state: "submitted")

--- a/spec/controllers/pafs_core/projects_controller_spec.rb
+++ b/spec/controllers/pafs_core/projects_controller_spec.rb
@@ -15,19 +15,17 @@ RSpec.describe PafsCore::ProjectsController, type: :controller do
     allow(subject).to receive(:current_resource) { @user }
   end
 
-  # FIXME: strange error with Kaminari in test where .page is not
-  # available on ActiveRecord::Relation for some reason
-  # describe "GET index" do
-  #   it "assigns @projects" do
-  #     get :index
-  #     expect(assigns(:projects)).to include(@project.reload)
-  #   end
-  #
-  #   it "renders the index template for html responses" do
-  #     get :index
-  #     expect(response).to render_template("index")
-  #   end
-  # end
+  describe "GET index" do
+    it "assigns @projects" do
+      get :index
+      expect(assigns(:projects)).to include(@project.reload)
+    end
+
+    it "renders the index template for html responses" do
+      get :index
+      expect(response).to render_template("index")
+    end
+  end
 
   describe "GET show" do
     it "assigns @project" do

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -5,6 +5,8 @@ FactoryGirl.define do
     reference_number { PafsCore::ProjectService.generate_reference_number("TH") }
     version 0
 
+    state
+
     factory :full_project do
       reference_number { PafsCore::ProjectService.generate_reference_number("SO") }
       version 0

--- a/spec/factories/state.rb
+++ b/spec/factories/state.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :state, class: PafsCore::State do
+    state { 'draft' }
+
+    PafsCore::State::VALID_STATES.each do |valid_state|
+      trait valid_state do
+        state { valid_state }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a new factory for the project state and extracts the valid states
to a constant to allow reuse of the valid states.