### PR TITLE
[PM-366] Fix data duplication on state change

### DIFF
--- a/app/models/pafs_core/project.rb
+++ b/app/models/pafs_core/project.rb
@@ -133,8 +133,10 @@ module PafsCore
     end
 
     def current_state
-      create_state(state: "draft") if state.nil?
-      state.state || "draft"
+      with_lock do
+        create_state(state: "draft") if state.nil?
+        state.state || "draft"
+      end
     end
   end
 end

--- a/lib/pafs_core.rb
+++ b/lib/pafs_core.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "pafs_core/engine"
 require "pafs_core/configuration"
 require "pafs_core/rfcc_codes"
@@ -25,6 +26,7 @@ require "pafs_core/files"
 require "pafs_core/fcerm1"
 require "pafs_core/email"
 require "pafs_core/custom_headers"
+require "pafs_core/data_migration/remove_duplicate_states"
 require "pafs_core/mapper/fcerm"
 require "pafs_core/mapper/funding_sources"
 require "pafs_core/mapper/partnership_funding_calculator"

--- a/lib/pafs_core/data_migration/remove_duplicate_states.rb
+++ b/lib/pafs_core/data_migration/remove_duplicate_states.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PafsCore
+  module DataMigration
+    class RemoveDuplicateStates
+      def self.perform_all
+        PafsCore::Project.find_each do |project|
+          new(project).perform
+        end
+      end
+
+      attr_reader :project
+
+      def initialize(project)
+        @project = project
+      end
+
+      def states
+        @states ||= PafsCore::State.where(project_id: project.id)
+      end
+
+      def has_duplicate_state?
+        states.size > 1
+      end
+
+      def duplicate_states
+        @duplicate_states ||= states.reject do |state| 
+          state.id == project.state.id
+        end
+      end
+
+      def perform
+        return unless has_duplicate_state?
+
+        duplicate_states.map(&:destroy)
+      end
+    end
+  end
+end

--- a/lib/tasks/pafs_core_tasks.rake
+++ b/lib/tasks/pafs_core_tasks.rake
@@ -1,6 +1,8 @@
 # Play nice with Ruby 3 (and rubocop)
 # frozen_string_literal: true
-# desc "Explaining what the task does"
-# task :pafs_core do
-#   # Task goes here
-# end
+
+namespace :pafs do
+  task remove_duplicate_states: :environment do
+    PafsCore::DataMigration::RemoveDuplicateStates.perform_all
+  end
+end

--- a/spec/lib/pafs_core/data_migration/remove_duplicate_states_spec.rb
+++ b/spec/lib/pafs_core/data_migration/remove_duplicate_states_spec.rb
@@ -1,0 +1,87 @@
+# Play nice with Ruby 3 (and rubocop)
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe PafsCore::DataMigration::RemoveDuplicateStates do
+  describe '#perform_all' do
+    let!(:project_1) { create(:project) }
+    let!(:project_2) { create(:project) }
+    let(:deduplicator) { double(:deduplicator, perform: true) }
+
+    it 'deduplicates all projects' do
+      expect(described_class).to receive(:new).with(project_1).and_return(deduplicator)
+      expect(described_class).to receive(:new).with(project_2).and_return(deduplicator)
+
+      described_class.perform_all
+    end
+  end
+
+  describe '#perform' do
+    let!(:project) { create(:project, state: state) }
+    let(:state) { create(:state, state: 'draft') }
+
+    subject { described_class.new(project) }
+
+    context 'without a duplicated status in the project' do
+      it 'does not delete the state' do
+        expect do
+          subject.perform
+        end.not_to change(PafsCore::State, :count)
+      end
+    end
+
+    context 'with a duplicated status in the project' do
+      before do
+        PafsCore::State.create(project_id: project.id, state: :draft)
+      end
+
+      it 'removes the duplicate state' do
+        expect do
+          subject.perform
+        end.to change(PafsCore::State, :count).by(-1)
+      end
+
+      it 'deleted the correct state' do
+        subject.perform
+        expect(project.reload.state.id).to eql(state.id)
+      end
+    end
+
+    context 'with two different states in the project' do
+      before do
+        PafsCore::State.create(project_id: project.id, state: :archived)
+      end
+
+      it 'removes the duplicate state' do
+        expect do
+          subject.perform
+        end.to change(PafsCore::State, :count).by(-1)
+      end
+
+      it 'deleted the correct state' do
+        subject.perform
+        expect(project.reload.state.id).to eql(state.id)
+      end
+    end
+
+    context 'with more than two states in the project' do
+      before do
+        PafsCore::State.create(project_id: project.id, state: :archived)
+        PafsCore::State.create(project_id: project.id, state: :submitted)
+        PafsCore::State.create(project_id: project.id, state: :draft)
+        PafsCore::State.create(project_id: project.id, state: :completed)
+      end
+
+      it 'removes the duplicate states' do
+        expect do
+          subject.perform
+        end.to change(PafsCore::State, :count).by(-4)
+      end
+
+      it 'deleted the correct states' do
+        subject.perform
+        expect(project.reload.state.id).to eql(state.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Rake task and service object to remove spurious state objects from projects
* Race condition when updating the project state can cause multiple state objects to be created for the same project.
* These duplicate states are affecting a join used to generate reports on the data, leading to duplicated rows.