### PR TITLE
[PM-404] Mod code should be 'Not Urgent' in JSON

### DIFF
--- a/app/presenters/pafs_core/spreadsheet_presenter.rb
+++ b/app/presenters/pafs_core/spreadsheet_presenter.rb
@@ -61,7 +61,7 @@ module PafsCore
       if urgent?
         I18n.t(project.urgency_reason, scope: "pafs_core.fcerm1.moderation")
       else
-        ""
+        I18n.t(:not_urgent, scope: "pafs_core.fcerm1.moderation")
       end
     end
 

--- a/config/locales/spreadsheet.en.yml
+++ b/config/locales/spreadsheet.en.yml
@@ -10,6 +10,7 @@ en:
         reservoir_flooding: "Reservoir Flooding"
         coastal_erosion: "Coastal Erosion"
       moderation:
+        not_urgent: "Not Urgent"
         statutory_need: "Statutory Requirement"
         legal_need: "Legal Agreement"
         health_and_safety: "Health & Safety"

--- a/spec/presenters/pafs_core/spreadsheet_presenter_spec.rb
+++ b/spec/presenters/pafs_core/spreadsheet_presenter_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PafsCore::SpreadsheetPresenter do
+  subject { described_class.new(project) }
+
+  describe "moderation_code" do
+    context 'with an urgent project' do
+      let(:project) { build(:project, urgency_reason: :legal_need) }
+
+      it 'returns the correct moderation code' do
+        expect(subject.moderation_code).to eql("Legal Agreement")
+      end
+    end
+
+    context  'with a non urgent project' do
+      let(:project) { build(:project, urgency_reason: :not_urgent) }
+
+      it 'returns "Not Urgent"' do
+        expect(subject.moderation_code).to eql("Not Urgent")
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
When a non-urgent project is rendered, the JSON should use 'Not Urgent'
ad the moderation code