### PR TITLE
[PM-436] Add wording to refer PSO's to PoL

### DIFF
--- a/app/views/pafs_core/projects/index.html.erb
+++ b/app/views/pafs_core/projects/index.html.erb
@@ -28,6 +28,10 @@
       <div class="create-new-project">
         <%= link_to t('create_a_new_project_label'), pafs_core.new_bootstrap_path, class: "button" %>
       </div>
+    <% else %>
+      <div class="create-new-project">
+        Go to PoL to Create New Project Proposals
+      </div>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
* Replaces the create project button with wording to refer PSO users to PoL
to create Projects.