### PR TITLE
[PM-357] Submitting a project sends it to PoL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   gem 'byebug'
   gem 'pry'
   gem 'guard-rspec', require: false
+  gem 'climate_control'
 end
 
 group :test do

--- a/app/controllers/pafs_core/projects_controller.rb
+++ b/app/controllers/pafs_core/projects_controller.rb
@@ -60,6 +60,7 @@ class PafsCore::ProjectsController < PafsCore::ApplicationController
     # send files to asite
     # asite.submit_project(@project)
     PafsCore::AsiteSubmissionJob.perform_later(@project.id)
+    PafsCore::Pol::SubmissionJob.perform_later(@project.id)
 
     redirect_to pafs_core.confirm_project_path(@project)
   end

--- a/app/jobs/pafs_core/pol/submission_job.rb
+++ b/app/jobs/pafs_core/pol/submission_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PafsCore
+  module Pol
+    class SubmissionJob < ActiveJob::Base
+      queue_as :default
+
+      def perform(project_id)
+        ActiveRecord::Base.connection_pool.with_connection do
+          PafsCore::Pol::Submission.perform(PafsCore::Project.find(project_id))
+        end
+      end
+    end
+  end
+end

--- a/lib/pafs_core.rb
+++ b/lib/pafs_core.rb
@@ -32,6 +32,7 @@ require "pafs_core/mapper/funding_sources"
 require "pafs_core/mapper/partnership_funding_calculator"
 require "pafs_core/pol/azure_oauth"
 require "pafs_core/pol/azure_vault_client"
+require "pafs_core/pol/submission"
 require "core_ext/time/financial"
 require "core_ext/date/financial"
 

--- a/lib/pafs_core/pol/submission.rb
+++ b/lib/pafs_core/pol/submission.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module PafsCore
+  module Pol
+    class Submission
+      def self.perform(project)
+        new(project).perform
+      end
+
+      attr_reader :project
+
+      def initialize(project)
+        @project = project
+      end
+
+      def perform
+        return unless submission_enabled?
+
+        connection.post do |request|
+          request.headers['Content-Type'] = 'application/json'
+          request.headers['x-function-key'] = api_token
+          request.body = payload
+        end
+      end
+
+      private
+
+      def json_presenter
+        @json_presenter ||= PafsCore::Camc3Presenter.new(project: project)
+      end
+
+      def payload
+        @payload ||= json_presenter.attributes.to_json
+      end
+
+      def url
+        ENV.fetch('POL_SUBMISSION_URL', nil).strip
+      end
+
+      def api_token
+        PafsCore::Pol::AzureVaultClient.fetch(
+          ENV.fetch('AZURE_VAULT_AUTH_TOKEN_KEY_NAME_SUBMISSION')
+        )
+      end
+
+      def connection
+        Faraday.new(url: url) do |faraday|
+          faraday.adapter Faraday.default_adapter
+        end
+      end
+
+      def submission_enabled?
+        !url.blank?
+      end
+    end
+  end
+end

--- a/spec/lib/pafs_core/pol/submission_spec.rb
+++ b/spec/lib/pafs_core/pol/submission_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PafsCore::Pol::Submission, :vcr do
+  let(:perform) { described_class.perform(project) }
+  let(:project) { double(:project) }
+
+  let(:url) { 'https://example.com/test' }
+  let!(:post_request) { stub_request(:post, 'https://example.com/test') }
+  let(:json_serializer) { double(:json_serializer, attributes: { test: 'value' }) }
+
+  before do
+    allow(PafsCore::Camc3Presenter).to receive(:new).with(
+      project: project
+    ).and_return(json_serializer)
+
+    allow(PafsCore::Pol::AzureVaultClient).to receive(:fetch).with('KEY_NAME').and_return('APITOKEN')
+  end
+
+  around do |example|
+    ClimateControl.modify(
+      POL_SUBMISSION_URL: url,
+      AZURE_VAULT_AUTH_TOKEN_KEY_NAME_SUBMISSION: 'KEY_NAME'
+    ) do
+      example.run
+    end
+  end
+
+  context 'with no POL_SUBMISSION_URL' do
+    let(:url) { '' }
+
+    it 'does not send anything to POL' do
+      perform
+      expect(post_request).not_to have_been_requested
+    end
+
+    it 'does not raise an error' do
+      expect do
+        perform
+      end.not_to raise_exception
+    end
+  end
+
+  context 'with a POL_SUBMISSION_URL' do
+    it 'submits the project to the correct URL' do
+      perform
+      expect(post_request).to have_been_requested.once
+    end
+
+    it 'encodes the project correctly' do
+      perform
+      expect(post_request.with(
+        body: '{"test":"value"}'
+      )).to have_been_requested.once
+    end
+
+    it 'sets the content type header' do
+      perform
+      expect(post_request.with(
+        headers: {'Content-Type' => 'application/json'}
+      )).to have_been_requested.once
+    end
+
+    it 'sets the api token header' do
+      perform
+      expect(post_request.with(
+        headers: {'x-function-key' => 'APITOKEN'}
+      )).to have_been_requested.once
+    end
+
+    it 'does not raise an error' do
+      expect do
+        perform
+      end.not_to raise_exception
+    end
+  end
+end


### PR DESCRIPTION
* Add a class to submit a project to Pol
* Requires two environment variables to be set:
  - POL_SUBMISSION_URL
    This is the url of the endpoint that receives the submission. This needs to be set in order to activate the submission to PoL. Without this, submission behaves as before.

  - AZURE_VAULT_AUTH_TOKEN_KEY_NAME_SUBMISSION
    This is the name of the key in Azure Vault that holds the
    authentication token for PoL to accept the request