### PR TITLE
[PM-451] Add submitted to pol scope

### DIFF
--- a/app/models/pafs_core/project.rb
+++ b/app/models/pafs_core/project.rb
@@ -29,6 +29,10 @@ module PafsCore
 
     before_validation :set_slug, on: :create
 
+    def self.submitted
+      joins(:state).merge(PafsCore::State.submitted)
+    end
+
     def self.refreshable
       joins(:state).merge(PafsCore::State.refreshable)
     end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -18,6 +18,16 @@ FactoryBot.define do
       benefit_area_file_name { nil }
     end
 
+    trait :submitted_to_pol do
+      association :state, :submitted
+      submitted_to_pol { 5.minutes.ago }
+    end
+
+    trait :submission_failed do
+      association :state, :submitted
+      submitted_to_pol { nil }
+    end
+
     factory :full_project do
       reference_number { PafsCore::ProjectService.generate_reference_number("SO") }
       version { 0 }


### PR DESCRIPTION
Adds a scope to the project that allows us to restrict to submitted projects. Also adds a couple of traits to allow testing of the project submission to PoL