### PR TITLE
[PM-526] Remove revert to draft button and fix edit capabilities

### DIFF
--- a/app/helpers/pafs_core/projects_helper.rb
+++ b/app/helpers/pafs_core/projects_helper.rb
@@ -31,6 +31,10 @@ module PafsCore
       !ENV.fetch('PSO_CANNOT_CREATE_PROJECTS', false)
     end
 
+    def can_revert_to_draft?(project)
+      !force_pso_to_use_pol?
+    end
+
     def can_change_project_state?(project)
       (rma_user? || pso_user?) && (!project.pso? || (project.pso? && !force_pso_to_use_pol?))
     end
@@ -40,7 +44,7 @@ module PafsCore
     end
 
     def can_edit_project_sections?(project)
-      !(project.pso? && force_pso_to_use_pol?)
+      !project.submitted? && !project.archived? && !(force_pso_to_use_pol? && project.pso?)
     end
 
     def project_status_change_link(project)

--- a/app/views/pafs_core/projects/_submit_project.html.erb
+++ b/app/views/pafs_core/projects/_submit_project.html.erb
@@ -38,7 +38,7 @@
       </div>
     </div>
   </section>
-<% elsif pso_user? && can_change_project_state?(project) && @project.submitted? %>
+<% elsif pso_user? && can_revert_to_draft?(project) && @project.submitted? %>
   <section aria-label="controls">
     <div class="grid-row">
       <div class="column-two-thirds">


### PR DESCRIPTION
* Reverting to draft is only possible via PoL once we turn on the force
to pol flag
* Editing projects should be restricted to non-submitted projects, and
only for rma projects or psos once the force-to-pol flag is false