### PR TITLE
[PM-539] Change `long_time_loss` to `long_term_loss`

### DIFF
--- a/lib/pafs_core/mapper/partnership_funding_calculator.rb
+++ b/lib/pafs_core/mapper/partnership_funding_calculator.rb
@@ -66,15 +66,15 @@ module PafsCore
             om3: {
               before_construction: {
                 most_deprived_20: {
-                  long_time_loss:         sheet.cell('F', 68),
+                  long_term_loss:         sheet.cell('F', 68),
                   medium_term_loss:       sheet.cell('G', 68),
                 },
                 most_deprived_21_40: {
-                  long_time_loss:         sheet.cell('F', 69),
+                  long_term_loss:         sheet.cell('F', 69),
                   medium_term_loss:       sheet.cell('G', 68),
                 },
                 least_deprived_60: {
-                  long_time_loss:         sheet.cell('F', 70),
+                  long_term_loss:         sheet.cell('F', 70),
                   medium_term_loss:       sheet.cell('G', 68),
                 },
               }

--- a/spec/lib/pafs_core/mapper/partnership_funding_calculator_spec.rb
+++ b/spec/lib/pafs_core/mapper/partnership_funding_calculator_spec.rb
@@ -117,14 +117,14 @@ RSpec.describe PafsCore::Mapper::PartnershipFundingCalculator do
     end
 
     it "has QBOM320LTB" do
-      expect(subject.attributes[:qualifying_benefits_outcome_measures][:om3][:before_construction][:most_deprived_20][:long_time_loss]).to eql(12)
+      expect(subject.attributes[:qualifying_benefits_outcome_measures][:om3][:before_construction][:most_deprived_20][:long_term_loss]).to eql(12)
     end
 
     it "has QBOM32140LTB" do
-      expect(subject.attributes[:qualifying_benefits_outcome_measures][:om3][:before_construction][:most_deprived_21_40][:long_time_loss]).to eql(12)
+      expect(subject.attributes[:qualifying_benefits_outcome_measures][:om3][:before_construction][:most_deprived_21_40][:long_term_loss]).to eql(12)
     end
     it "has QBOM360LTB" do
-      expect(subject.attributes[:qualifying_benefits_outcome_measures][:om3][:before_construction][:least_deprived_60][:long_time_loss]).to eql(12)
+      expect(subject.attributes[:qualifying_benefits_outcome_measures][:om3][:before_construction][:least_deprived_60][:long_term_loss]).to eql(12)
     end
 
     it "has QBOM320MTB" do


### PR DESCRIPTION
Looks like a typo. Fixed as requested by PF