### PR TITLE
[PM-545] Update confirmation page wording

### DIFF
--- a/app/controllers/pafs_core/projects_controller.rb
+++ b/app/controllers/pafs_core/projects_controller.rb
@@ -81,14 +81,12 @@ class PafsCore::ProjectsController < PafsCore::ApplicationController
     @project = navigator.find(params[:id])
     if @project.archived?
       render "confirm_archive"
-    elsif @project.completed?
+    elsif @project.completed? || @project.submitted?
       if current_resource.primary_area.rma?
         render "confirm_rma"
       else
         render "confirm_pso"
       end
-    elsif @project.submitted?
-      render "confirm_area"
     else
       redirect_to pafs_core.project_path(@project)
     end

--- a/app/views/pafs_core/projects/confirm_pso.html.erb
+++ b/app/views/pafs_core/projects/confirm_pso.html.erb
@@ -5,11 +5,6 @@
       <%= render partial: "confirm_banner",
         locals: { reference_number: @project.reference_number,
                   title: "Proposal under review" } %>
-      <h2 class="heading-medium">What happens next?</h2>
-      <ul class="list list-bullet">
-        <li>Review your proposal</li>
-        <li>Return to the <%= link_to "proposal overview", project_path(@project) %> page and click the 'Mark as submitted' button</li>
-      </ul>
 
       <h2 class="heading-medium">If you need to change your proposal</h2>
       <ul class="list list-bullet">

--- a/app/views/pafs_core/projects/confirm_pso.html.erb
+++ b/app/views/pafs_core/projects/confirm_pso.html.erb
@@ -13,8 +13,7 @@
 
       <h2 class="heading-medium">If you need to change your proposal</h2>
       <ul class="list list-bullet">
-        <li>Return to the <%= link_to "proposal overview", project_path(@project) %> page and click the 'Revert to draft' button</li>
-        <li>Once you have completed your changes, click the 'Submit for review' button</li>
+        <li>Login to Project Online where this project can now be viewed and edited.</li>
       </ul>
 
       <div class="form-group headroom">

--- a/app/views/pafs_core/projects/confirm_rma.html.erb
+++ b/app/views/pafs_core/projects/confirm_rma.html.erb
@@ -9,9 +9,7 @@
       <p>We've sent your proposal to your <%= link_to t("strategic_officer_label"), t("strategic_officer_link"), target: "_blank", rel: "external" %> for consideration. They'll contact you if they need more information.</p>
 
       <h2 class="heading-medium">If you need to change your proposal</h2>
-      <p>If you have any questions, or need to make changes to your proposal, contact your
-      <%= link_to t("strategic_officer_label"), t("strategic_officer_link"), target: "_blank", rel: "external" %>.</p>
-      <p>You'll need to quote your national project number.</p>
+      <p>Get in touch with your local Environment Agency contact who will be able to revert your proposal back to ‘draft’ status.</p>
 
       <div class="form-group headroom">
       <%= link_to "Return to your proposals", projects_path, class: "button", role: "button" %>

--- a/app/views/pafs_core/projects/confirm_rma.html.erb
+++ b/app/views/pafs_core/projects/confirm_rma.html.erb
@@ -5,9 +5,6 @@
       <%= render partial: "confirm_banner",
         locals: { reference_number: @project.reference_number,
                   title: "Proposal sent for review" } %>
-      <h2 class="heading-medium">What happens next?</h2>
-      <p>We've sent your proposal to your <%= link_to t("strategic_officer_label"), t("strategic_officer_link"), target: "_blank", rel: "external" %> for consideration. They'll contact you if they need more information.</p>
-
       <h2 class="heading-medium">If you need to change your proposal</h2>
       <p>Get in touch with your local Environment Agency contact who will be able to revert your proposal back to ‘draft’ status.</p>
 


### PR DESCRIPTION
With the new workflow in place the RMA or the PSO, can no longer revert
the proposal back to draft.

Therefore the content on the confirmation page needs to change.