### PR TITLE
[PM-546] Allow imports to specify the project status

### DIFF
--- a/app/decorators/pafs_core/imported_project_decorator.rb
+++ b/app/decorators/pafs_core/imported_project_decorator.rb
@@ -6,7 +6,7 @@ module PafsCore
       PafsCore::EnvironmentalOutcomes
 
     def project_status=(value)
-      project.create_state(state: value)
+      PafsCore::Projects::StatusUpdate.new(project, value).perform
     end
 
     def reference_number=(value)

--- a/app/services/pafs_core/projects/status_update.rb
+++ b/app/services/pafs_core/projects/status_update.rb
@@ -1,0 +1,33 @@
+module PafsCore
+  module Projects
+    class StatusUpdate
+      attr_reader :project, :status
+
+      STATUS_MAP = {
+        'Draft': :draft,
+        'Review': :completed,
+        'Submitted': :submitted,
+        'Archived': :archived
+      }
+
+      def initialize(project, status)
+        @project = project
+        @status = status.to_sym
+      end
+
+      def coerced_status
+        return status if STATUS_MAP.values.include?(status)
+
+        STATUS_MAP[status] || :draft
+      end
+
+      def state
+        project.state || project.create_state
+      end
+
+      def perform
+        state.update_attribute(:state, coerced_status)
+      end
+    end
+  end
+end

--- a/app/services/pafs_core/projects/status_update.rb
+++ b/app/services/pafs_core/projects/status_update.rb
@@ -12,7 +12,7 @@ module PafsCore
 
       def initialize(project, status)
         @project = project
-        @status = status.to_sym
+        @status = status&.to_sym
       end
 
       def coerced_status

--- a/spec/services/pafs_core/projects/status_update_spec.rb
+++ b/spec/services/pafs_core/projects/status_update_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PafsCore::Projects::StatusUpdate do
+  describe 'with a valid new status' do
+    STATUS_MAP = {
+      'Draft': :draft,
+      'Review': :completed,
+      'Submitted': :submitted,
+      'Archived': :archived
+    }
+
+    let(:project) { create(:project) }
+
+    STATUS_MAP.each do |k, v|
+      it "sets the status of the project to #{v} when given #{v}" do
+        described_class.new(project, v).perform
+        expect(project.reload.status).to eql(v)
+      end
+
+      it "sets the status of the project to #{v} when given #{k}" do
+        described_class.new(project, k).perform
+        expect(project.reload.status).to eql(v)
+      end
+    end
+
+    it 'sets the project status to draft when an invalid status is received' do
+      described_class.new(project, 'INVALID').perform
+      expect(project.reload.status).to eql(:draft)
+    end
+  end
+end
+


### PR DESCRIPTION
* FCERM import would previously not correctly coerce the project status
* This lead to the status always being set to draft
* This fix correctly coerces the values from the status filed and
assigns the correct state.