### PR TITLE
[PM-568] Add defaults to PFC mapper

### DIFF
--- a/app/presenters/pafs_core/partnership_funding_calculator_presenter.rb
+++ b/app/presenters/pafs_core/partnership_funding_calculator_presenter.rb
@@ -17,7 +17,7 @@ class PafsCore::PartnershipFundingCalculatorPresenter
   end
 
   def attributes
-    return {} if mapper.nil?
+    return PafsCore::Mapper::PartnershipFundingCalculator.default_attributes if mapper.nil?
 
     mapper.attributes
   end

--- a/lib/pafs_core/mapper/partnership_funding_calculator.rb
+++ b/lib/pafs_core/mapper/partnership_funding_calculator.rb
@@ -6,6 +6,78 @@ module PafsCore
 
       attr_accessor :sheet
 
+      def self.default_attributes
+        {
+          pv_appraisal_approach: nil,
+          pv_design_and_construction_costs: nil,
+          pv_funding_from_other_ea_functions_sources_secured_to_date: nil,
+          pv_local_levy_secured_to_date: nil,
+          pv_post_construction_costs: nil,
+          pv_private_contributions_secured_to_date: nil,
+          pv_public_contributions_secured_to_date: nil,
+          pv_whole_life_benefits: nil,
+          qualifying_benefits_outcome_measures: {
+            om2: {
+              before: {
+                most_deprived_20: {
+                  moderate_risk: nil,
+                  significant_risk: nil,
+                  very_significant_risk: nil,
+                },
+                most_deprived_21_40: {
+                  moderate_risk: nil,
+                  significant_risk: nil,
+                  very_significant_risk: nil,
+                },
+                least_deprived_60: {
+                  moderate_risk: nil,
+                  significant_risk: nil,
+                  very_significant_risk: nil,
+                }
+              },
+              after: {
+                most_deprived_20: {
+                  moderate_risk: nil,
+                  significant_risk: nil,
+                  very_significant_risk: nil,
+                },
+                most_deprived_21_40: {
+                  moderate_risk: nil,
+                  significant_risk: nil,
+                  very_significant_risk: nil,
+                },
+                least_deprived_60: {
+                  moderate_risk: nil,
+                  significant_risk: nil,
+                  very_significant_risk: nil,
+                }
+              }
+            },
+            om3: {
+              before_construction: {
+                most_deprived_20: {
+                  long_term_loss: nil,
+                  medium_term_loss: nil,
+                },
+                most_deprived_21_40: {
+                  long_term_loss: nil,
+                  medium_term_loss: nil,
+                },
+                least_deprived_60: {
+                  long_term_loss: nil,
+                  medium_term_loss: nil,
+                },
+              }
+            },
+            om4: {
+              hectares_of_net_water_dependent_habitat_created: nil,
+              hectares_of_net_water_intertidal_habitat_created: nil,
+              kilometres_of_protected_river_improved: nil,
+            }
+          }
+        }
+      end
+
       def initialize(calculator_file:)
         self.calculator_file = calculator_file
         self.attributes = {}


### PR DESCRIPTION
This allows PoL to process the output JSON in the case that the project
being serialized does not have a PFC by adding default, null values to
the output, and preserving the structure.