### PR TITLE
[PM-612] Reduce memory usage when uploading to S3

### DIFF
--- a/app/services/pafs_core/development_file_storage_service.rb
+++ b/app/services/pafs_core/development_file_storage_service.rb
@@ -23,7 +23,11 @@ module PafsCore
     def upload_data(io_object, to_path)
       dest = file_path(to_path)
       FileUtils.mkdir_p(File.dirname(dest))
-      File.open(dest, "wb") { |f| f.write(io_object) }
+      io_object = StringIO.new(io_object) if io_object.is_a?(String)
+
+      File.open(dest, "wb") do |dest_file|
+        IO.copy_stream(io_object, dest_file)
+      end
     rescue StandardError => e
       raise PafsCore::FileNotFoundError, "Something went wrong: #{dest}\n#{e}"
     end

--- a/app/services/pafs_core/download/meta.rb
+++ b/app/services/pafs_core/download/meta.rb
@@ -30,6 +30,8 @@ module PafsCore
         end
 
         block_given? ? yield(@_file_content) : @_file_content
+      rescue JSON::ParserError
+        nil
       end
 
       def exists?

--- a/lib/pafs_core/files.rb
+++ b/lib/pafs_core/files.rb
@@ -69,9 +69,18 @@ module PafsCore
       end
 
       puts "Generation complete"
-      puts "Uploading"
-      storage.upload_data(xlsx.stream.read, filename)
-      puts "Upload complete"
+      tmpfile = Tempfile.new(["multi_fcerm1", ".xlsx"])
+
+      begin
+        xlsx.write(tmpfile.path)
+
+        puts "Uploading"
+        storage.upload_data(tmpfile, filename)
+        puts "Upload complete"
+      ensure
+        tmpfile.close
+        tmpfile.unlink
+      end
     end
 
     def generate_benefit_areas_file(projects, filename)
@@ -88,7 +97,8 @@ module PafsCore
       end
 
       # store file
-      storage.upload_data(File.read(tmpfile.path), filename)
+      tmpfile.rewind
+      storage.upload_data(tmpfile, filename)
     ensure
       tmpfile.close
       tmpfile.unlink
@@ -108,7 +118,8 @@ module PafsCore
       end
 
       # store file
-      storage.upload_data(File.read(tmpfile.path), filename)
+      tmpfile.rewind
+      storage.upload_data(tmpfile, filename)
     ensure
       tmpfile.close
       tmpfile.unlink
@@ -128,7 +139,8 @@ module PafsCore
       end
 
       # store file
-      storage.upload_data(File.read(tmpfile.path), filename)
+      tmpfile.rewind
+      storage.upload_data(tmpfile, filename)
     ensure
       tmpfile.close
       tmpfile.unlink


### PR DESCRIPTION
When generating a new FCRM1, the upload portion reads the file into
memory and causes a spike in memory usage. This can be significant
enough to crash the server due to OOM errors.

Rather than read the file into memory, it should be streamed to s3. No
functionality should change when generating or downloading FCRM1 or
related files.