### PR TITLE
[PM-613] Add switch to skip PSO confirmation on submit

### DIFF
--- a/app/helpers/pafs_core/projects_helper.rb
+++ b/app/helpers/pafs_core/projects_helper.rb
@@ -24,6 +24,10 @@ module PafsCore
       I18n.t("#{state}_label", scope: scope)
     end
 
+    def skip_pso_confirmation?
+      ENV.fetch("SKIP_PSO_CONFIRMATION", false)
+    end
+
     def force_pso_to_use_pol?
       ENV.fetch("FORCE_PSO_TO_POL", false)
     end

--- a/app/views/pafs_core/projects/_submit_project.html.erb
+++ b/app/views/pafs_core/projects/_submit_project.html.erb
@@ -10,7 +10,7 @@
         <div class="column-two-thirds">
             <p><%= @project.summary_label(:submission_notice) %></p>
             <%= render partial: "summary/data_notice", locals: { project: @project } %>
-            <% if force_pso_to_use_pol? %>
+            <% if skip_pso_confirmation? %>
               <%= link_to t("submit_project_label"),
                 submit_project_path(id: @project.to_param), class: "button submit-proposal" %>
             <% else %>


### PR DESCRIPTION
When submitting a project as an RMA, we need to allow the business to
switch the confirmation of a project by a PSO off.

New env var SKIP_PSO_CONFIRMATION handles this option.