### PR TITLE
APP-2715 - Change any text referring to  ‘Growth’ funding to read  ‘Additional’ Grant-in-Aid’.

### DIFF
--- a/config/locales/funding_sources.en.yml
+++ b/config/locales/funding_sources.en.yml
@@ -5,7 +5,7 @@ en:
     public_contributions: "Public sector contributions"
     private_contributions: "Private sector contributions"
     other_ea_contributions: "Contributions from other Environment Agency functions or sources"
-    growth_funding: "Growth funding"
+    growth_funding: "Additional Grant-in-Aid"
     internal_drainage_boards: "Funds recovered from an internal drainage board by the Environment Agency, known as a precept"
     not_yet_identified: "Other funding sources not yet identified"
 
@@ -15,6 +15,6 @@ en:
       public_contributions: "Public sector"
       private_contributions: "Private sector"
       other_ea_contributions: "Other Environment Agency functions"
-      growth_funding: "Growth funding"
+      growth_funding: "Additional Grant-in-Aid"
       internal_drainage_boards: "Internal drainage board"
       not_yet_identified: "Other funding sources"

--- a/config/locales/steps.en.yml
+++ b/config/locales/steps.en.yml
@@ -104,7 +104,7 @@ en:
           public_contributions_label: Public sector contributions
           private_contributions_label: Private sector contributions
           other_ea_contributions_label: Other Environment Agency contributions
-          growth_funding_label: Growth funding
+          growth_funding_label: Additional Grant-in-Aid
           not_yet_identified_label: Not yet identified
           total_label: Total (£)
         public_contributor_values:

--- a/config/locales/summary.en.yml
+++ b/config/locales/summary.en.yml
@@ -43,7 +43,7 @@ en:
       public_contributions_label: "Public sector contributions"
       private_contributions_label: "Private sector contributions"
       other_ea_contributions_label: "Other Environment Agency contributions"
-      growth_funding_label: "Growth funding"
+      growth_funding_label: "Additional Grant-in-Aid"
       not_yet_identified_label: "Not yet identified"
       total_label: "Total (£)"
       flood_protection_outcomes_detail_heading: "Households affected by flooding benefited by the project"


### PR DESCRIPTION
In the funding sources and spending section, we need to change any text referring to  ‘Growth’ funding to read  ‘Additional’ Grant-in-Aid’. Growth is the original term used to describe what is now known as Additional Grant in Aid.


[APP-2715 - Change any text referring to  ‘Growth’ funding to read  ‘Additional’ Grant-in-Aid’.](https://eaflood.atlassian.net/jira/software/c/projects/APP/boards/539?modal=detail&selectedIssue=APP-2715&quickFilter=1303)