### PR TITLE
Remove 2026 maximum for om figures

### DIFF
--- a/app/presenters/pafs_core/camc3_presenter.rb
+++ b/app/presenters/pafs_core/camc3_presenter.rb
@@ -204,22 +204,6 @@ class PafsCore::Camc3Presenter
   attr_accessor :funding_sources_mapper
 
   def financial_years
-    [
-      -1,
-      2015,
-      2016,
-      2017,
-      2018,
-      2019,
-      2020,
-      2021,
-      2022,
-      2023,
-      2024,
-      2025,
-      2026,
-      2027,
-      2028
-    ]
+    [-1] + (2015..project.project_end_financial_year).to_a
   end
 end

--- a/app/presenters/pafs_core/spreadsheet_presenter.rb
+++ b/app/presenters/pafs_core/spreadsheet_presenter.rb
@@ -313,33 +313,15 @@ module PafsCore
     end
 
     def flood_protection_for(year)
-      if year > 2026
-        # sum up 2027 onwards for spreadsheet
-        t = PafsCore::FloodProtectionOutcome.arel_table
-        project.flood_protection_outcomes.where(t[:financial_year].gt(year - 1))
-      else
-        project.flood_protection_outcomes.where(financial_year: year)
-      end
+      project.flood_protection_outcomes.where(financial_year: year)
     end
 
     def flood_protection_2040_for(year)
-      if year > 2026
-        # sum up 2027 onwards for spreadsheet
-        t = PafsCore::FloodProtectionOutcome.arel_table
-        project.flood_protection2040_outcomes.where(t[:financial_year].gt(year - 1))
-      else
-        project.flood_protection2040_outcomes.where(financial_year: year)
-      end
+      project.flood_protection2040_outcomes.where(financial_year: year)
     end
 
     def coastal_erosion_protection_for(year)
-      if year > 2026
-        # sum up 2027 onwards for spreadsheet
-        t = PafsCore::CoastalErosionProtectionOutcome.arel_table
-        project.coastal_erosion_protection_outcomes.where(t[:financial_year].gt(year - 1))
-      else
-        project.coastal_erosion_protection_outcomes.where(financial_year: year)
-      end
+      project.coastal_erosion_protection_outcomes.where(financial_year: year)
     end
 
     def sum_flood_protection_for(year, category)

--- a/spec/presenters/pafs_core/camc3_presenter_spec.rb
+++ b/spec/presenters/pafs_core/camc3_presenter_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PafsCore::Camc3Presenter do
       :ea_area,
       :with_no_shapefile,
       {
-        project_end_financial_year: 2027,
+        project_end_financial_year: 2032,
         funding_calculator_file_name: calculator_file
       }
     )
@@ -68,7 +68,11 @@ RSpec.describe PafsCore::Camc3Presenter do
       { year: 2025, value: 0 },
       { year: 2026, value: 0 },
       { year: 2027, value: 0 },
-      { year: 2028, value: 0 }
+      { year: 2028, value: 0 },
+      { year: 2029, value: 0 },
+      { year: 2030, value: 0 },
+      { year: 2031, value: 0 },
+      { year: 2032, value: 0 }
     ]
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/RUBY/boards/374?selectedIssue=RUBY-1974

This is an old FCERM1 requirement that is no longer needed for AIMS PD

Prior to its removal, it summed up all properties protected past 2026 in each year past 2026.

Also changes the financial years the cam3cpresenter to go up to the projects' financial year end rather than the arbitrary fixed value of 2028.