### PR TITLE
Specify PafsCore namespace for ApplicationController inheritance

### DIFF
--- a/app/controllers/pafs_core/archives_controller.rb
+++ b/app/controllers/pafs_core/archives_controller.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class ArchivesController < ApplicationController
+  class ArchivesController < PafsCore::ApplicationController
     def index
       page = params.fetch(:page, 1)
       projects_per_page = params.fetch(:per, 10)

--- a/app/controllers/pafs_core/areas_controller.rb
+++ b/app/controllers/pafs_core/areas_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class AreasController < ApplicationController
+  class AreasController < PafsCore::ApplicationController
     # NOTE: this should be added via a decorator in consuming qpp if needed
     # before_action :authenticate_user!
 

--- a/app/controllers/pafs_core/bootstraps_controller.rb
+++ b/app/controllers/pafs_core/bootstraps_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class BootstrapsController < ApplicationController
+  class BootstrapsController < PafsCore::ApplicationController
     # NOTE: this should be added via a decorator in consuming qpp if needed
     # before_action :authenticate_user!
 

--- a/app/controllers/pafs_core/downloads_controller.rb
+++ b/app/controllers/pafs_core/downloads_controller.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class DownloadsController < ApplicationController
+  class DownloadsController < PafsCore::ApplicationController
     include PafsCore::Files
 
     def index

--- a/app/controllers/pafs_core/errors_controller.rb
+++ b/app/controllers/pafs_core/errors_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class ErrorsController < ApplicationController
+  class ErrorsController < PafsCore::ApplicationController
     def show
       @exception = ENV["action_dispatch.exception"]
       action = request.path[1..-1].gsub(/[^0-9]/, "")

--- a/app/controllers/pafs_core/multi_downloads_controller.rb
+++ b/app/controllers/pafs_core/multi_downloads_controller.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class MultiDownloadsController < ApplicationController
+  class MultiDownloadsController < PafsCore::ApplicationController
     include PafsCore::Files
 
     def index

--- a/app/controllers/pafs_core/pages_controller.rb
+++ b/app/controllers/pafs_core/pages_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PafsCore
-  class PagesController < ApplicationController
+  class PagesController < PafsCore::ApplicationController
     helper_method :previous_page
 
     def cookies; end

--- a/spec/services/pafs_core/calculator_parser_spec.rb
+++ b/spec/services/pafs_core/calculator_parser_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe PafsCore::CalculatorParser do
       it "parses and saves the raw_partnership_funding_score" do
         expect do
           perform
-        end.to change { project.reload.raw_partnership_funding_score }.to(59.3077682362934)
+        end.to change { project.reload.raw_partnership_funding_score&.round(13) }.to(59.3077682362934)
       end
 
       it "parses and saves the adjusted_partnership_funding_score" do
         expect do
           perform
-        end.to change { project.reload.adjusted_partnership_funding_score }.to(61.1982816278954)
+        end.to change { project.reload.adjusted_partnership_funding_score&.round(13) }.to(61.1982816278954)
       end
 
       it "parses and saves the pv_whole_life_costs" do
@@ -79,13 +79,13 @@ RSpec.describe PafsCore::CalculatorParser do
       it "parses and saves the raw_partnership_funding_score" do
         expect do
           perform
-        end.to change { project.reload.raw_partnership_funding_score }.to(119_962.642857253)
+        end.to change { project.reload.raw_partnership_funding_score&.round(9) }.to(119_962.642857253)
       end
 
       it "parses and saves the adjusted_partnership_funding_score" do
         expect do
           perform
-        end.to change { project.reload.adjusted_partnership_funding_score }.to(1_199_626.42857253)
+        end.to change { project.reload.adjusted_partnership_funding_score&.round(8) }.to(1_199_626.42857253)
       end
 
       it "parses and saves the pv_whole_life_costs" do


### PR DESCRIPTION
This change disambiguates inheritance from `ApplicationController`, ensuring that `PafsCore` controllers inherit from `PafsCore::ApplicationController` and no other `ApplicationController` class.
https://eaflood.atlassian.net/browse/RUBY-2108