### PR TITLE
Fix form-group id error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk_design_system_formbuilder (3.1.2)
+    govuk_design_system_formbuilder (3.3.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -290,7 +290,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.23.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.17.2)
+    rubocop-rails (2.17.3)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
@@ -334,7 +334,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.5)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby

--- a/app/views/pafs_core/projects/show.html.erb
+++ b/app/views/pafs_core/projects/show.html.erb
@@ -38,7 +38,7 @@
 
     <% @project.articles.each do |item| %>
       <div class="govuk-grid-column govuk-body-s">
-        <%= form_group(f, item) do %>
+        <%= form_group("project", item) do %>
           <%= error_message(@project, item) %>
           <%= render partial: "summary/#{item}", locals: { project: @project } %>
           <% end -%>


### PR DESCRIPTION
This fixes a bug where a form object instead of a "project" prefix was being passed to the `form_group` helper.
https://eaflood.atlassian.net/browse/RUBY-2178