### PR TITLE
Always allow area download generation

### DIFF
--- a/app/services/pafs_core/area_download_service.rb
+++ b/app/services/pafs_core/area_download_service.rb
@@ -37,9 +37,12 @@ module PafsCore
       end
     end
 
+    # This previously returned false if the current status was "generating", in order to prevent duplicate
+    # generation jobs, but that caused issues with the status stuck at "generating" after an error.
+    # Currently allowing job submission in all cases.
+    # Leaving the method in place to allow for future restrictions such as a minimum time interval between requests.
     def can_generate_documentation?
-      ds = download_info.documentation_state
-      ds.empty? || ds.ready? || ds.failed?
+      true
     end
 
     # NOTE: Call me from a Job as I take a long time to complete

--- a/spec/services/pafs_core/area_download_service_spec.rb
+++ b/spec/services/pafs_core/area_download_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PafsCore::AreaDownloadService do
+
+  subject(:service) { described_class.new(user) }
+
+  let(:user) { create(:user) }
+  let(:area) { create(:rma_area) }
+
+  before do
+    PafsCore::UserArea.create(user: user, area: area, primary: true)
+    area.create_area_download
+  end
+
+  describe "#can_generate_documentation?" do
+
+    context "with no previous generation request" do
+      it "returns true" do
+        expect(service.can_generate_documentation?).to be true
+      end
+    end
+
+    context "with a previous generation request and generation status 'failed'" do
+      before do
+        info = area.create_area_download
+        info.documentation_state.generate!
+        info.documentation_state.error!
+        info.save!
+      end
+
+      it "returns true" do
+        expect(service.can_generate_documentation?).to be true
+      end
+    end
+
+    context "with a previous generation request and generation status 'generating'" do
+      before do
+        info = area.create_area_download
+        info.documentation_state.generate!
+        info.save!
+      end
+
+      # This previously returned false to prevent duplicate generation jobs, but that caused issues
+      # with the status stuck at "generating" after an error. Currently allowing job submission in all cases.
+      it "returns true" do
+        expect(service.can_generate_documentation?).to be true
+      end
+    end
+  end
+
+  describe "#generate_downloads" do
+    before { allow(PafsCore::GenerateAreaProgrammeJob).to receive(:perform_later) }
+
+    it "submits a generation job" do
+      service.generate_downloads
+
+      expect(PafsCore::GenerateAreaProgrammeJob).to have_received(:perform_later)
+    end
+  end
+end


### PR DESCRIPTION
This changes the rules for starting an area download generation job. Previously, submission was prevented if the status was "generating", in order to prevent duplicate jobs. However this caused issues in some cases where the previous generation job had failed and the status was stuck at "generating". This change allows job submission regardless of the current state.
https://eaflood.atlassian.net/browse/RUBY-2409