### PR TITLE
Handle missing owner in moderation presenter

### DIFF
--- a/app/presenters/pafs_core/moderation_presenter.rb
+++ b/app/presenters/pafs_core/moderation_presenter.rb
@@ -5,6 +5,9 @@ module PafsCore
     include PafsCore::Urgency
 
     def body
+      # In the event of bad data, log an error but continue presenting
+      Airbrake.notify("Missing project owner for project #{project.reference_number}") if project.owner.blank?
+
       f = PafsCore::Engine.root.join("app", "views", "pafs_core", "projects", "downloads", "moderation.txt.erb")
       s = ERB.new(File.read(f)).result(binding)
       # make it friendly for the Winders users

--- a/app/services/pafs_core/area_download_service.rb
+++ b/app/services/pafs_core/area_download_service.rb
@@ -54,7 +54,7 @@ module PafsCore
     rescue StandardError => e
       Airbrake.notify(e)
       # send failure notification email
-      PafsCore::AptNotificationMailer.area_programme_generation_failed(download_info, e).deliver_now
+      PafsCore::AptNotificationMailer.area_programme_generation_failed(download_info).deliver_now
       raise e
     end
 

--- a/app/views/pafs_core/multi_downloads/_generating.html.erb
+++ b/app/views/pafs_core/multi_downloads/_generating.html.erb
@@ -15,10 +15,10 @@
         <p>
           As the requestor, you will receive an email once the programme is ready to download.
         </p>
-        <p>
-          <%= link_to "Generate programme again", pafs_core.generate_multi_downloads_path, class: "button", role: "button" %>
-        </p>
       <% end %>
+      <p>
+        <%= link_to "Generate programme again", pafs_core.generate_multi_downloads_path, class: "button", role: "button" %>
+      </p>
     </div>
   </div>
 </div>

--- a/app/views/pafs_core/projects/downloads/moderation.txt.erb
+++ b/app/views/pafs_core/projects/downloads/moderation.txt.erb
@@ -15,10 +15,10 @@ Urgency Moderation Evidence
 <% end %>
 ------------------------------------------------------
 * Risk Management Authority
-  <%= project.owner.name %>
+  <%= project.owner&.name %>
 
 * Environment Agency Area
-  <%= project.owner.ea_parent.name %>
+  <%= project.owner&.ea_parent&.name %>
 
 * Regional Flood and Coastal Committee
   <%= PafsCore::RFCC_CODE_NAMES_MAP.fetch(project.reference_number[0..1]) %>

--- a/lib/pafs_core/configuration.rb
+++ b/lib/pafs_core/configuration.rb
@@ -63,12 +63,6 @@ module PafsCore
         configuration.logger = Rails.logger
         configuration.environment = ENV.fetch("AIRBRAKE_ENV_NAME", Rails.env)
       end
-
-      # Prevent Airbrake from trying to auto-load remote config from Airbrake servers
-      # as this fails (our projects are not on Airbrake) and disables Airbrake in the app
-      Airbrake.configure do |c|
-        c.remote_config = false
-      end
     end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     reference_number { PafsCore::ProjectService.generate_reference_number("TH") }
     name { Faker::Lorem.sentence }
     version { 0 }
+    created_at { 1.day.ago }
+    updated_at { 1.day.ago }
     project_end_financial_year { 2022 }
     private_contributions { private_contribution_names.any? }
     public_contributions { public_contribution_names.any? }

--- a/spec/presenters/pafs_core/moderation_presenter_spec.rb
+++ b/spec/presenters/pafs_core/moderation_presenter_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PafsCore::ModerationPresenter do
+  subject(:presenter) { described_class.new(project) }
+
+  let(:project) { build(:project, :ea_area, urgency_reason: urgency_reason) }
+  let(:urgency_reason) { nil }
+
+  describe "#body" do
+    before { allow(Airbrake).to receive :notify }
+
+    it "renders the template" do
+      expect { presenter.body }.not_to raise_error
+    end
+
+    it "does not report an error" do
+      presenter.body
+
+      expect(Airbrake).not_to have_received :notify
+    end
+
+    context "with a missing owner" do
+      before { project.area_projects.update(owner: false) }
+
+      it "reports an error" do
+        presenter.body
+
+        expect(Airbrake).to have_received(:notify).at_least(:once)
+      end
+    end
+  end
+
+  describe "#pretty_urgency_reason" do
+    context "with no urgency reason" do
+      let(:urgency_reason) { nil }
+
+      it "returns an empty string" do
+        expect(presenter.pretty_urgency_reason).to eq ""
+      end
+    end
+
+    context "with an urgency reason" do
+      let(:urgency_reason) { "statutory_need" }
+
+      it "returns an empty string" do
+        expect(presenter.pretty_urgency_reason).to eq "A business critical statutory need"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some projects in production do not have an owning area and this trips up the `moderation_presenter`. This change allows the presenter to show blank values, while also logging an error to Errbit with the project's reference number so that these projects can be flagged for corrective action.
https://eaflood.atlassian.net/browse/RUBY-2388