### PR TITLE
Feature/ruby 2436 pafs add secondary risk sources to json

### DIFF
--- a/app/presenters/pafs_core/camc3_presenter.rb
+++ b/app/presenters/pafs_core/camc3_presenter.rb
@@ -130,6 +130,10 @@ module PafsCore
       end
     end
 
+    def secondary_risk_sources
+      PafsCore::Risks::RISKS.index_with { |risk| risk.to_s != project.main_risk && project.send(risk) }
+    end
+
     def base64_shapefile
       @base64_shapefile ||= PafsCore::ShapefileSerializer.serialize(project)
     end
@@ -192,7 +196,8 @@ module PafsCore
                          beach_nourishment: project.beach_nourishment,
                          other_flood_measures: project.other_flood_measures,
                          natural_flood_risk_measures_cost: project.natural_flood_risk_measures_cost
-                       }
+                       },
+                       secondary_risk_sources: secondary_risk_sources
                      }
                    )
     end

--- a/doc/json_schemas/project.json
+++ b/doc/json_schemas/project.json
@@ -982,6 +982,50 @@
             }
           }
         }
+      },
+      "secondary_risk_sources": {
+        "fluvial_flooding": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "tidal_flooding": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "groundwater_flooding": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "surface_water_flooding": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "sea_flooding": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "reservoir_flooding": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "coastal_erosion": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
       }
     }
   }

--- a/spec/presenters/pafs_core/camc3_presenter_spec.rb
+++ b/spec/presenters/pafs_core/camc3_presenter_spec.rb
@@ -176,6 +176,18 @@ RSpec.describe PafsCore::Camc3Presenter do
           expect(subject.attributes[:secondary_risk_sources]).to have_key(sra)
         end
       end
+
+      it "renders main risk as false in secondary list" do
+        expect(subject.attributes[:secondary_risk_sources][project.main_risk.to_sym]).to be_falsey
+      end
+
+      it "renders risk source values" do
+        PafsCore::Risks::RISKS.each do |risk|
+          next if risk == project.main_risk.to_sym
+
+          expect(subject.attributes[:secondary_risk_sources][risk]).to eql(project.send(risk))
+        end
+      end
     end
 
     shared_examples "has the expected forecast" do |outcomes_category, attribute, presenter_method = nil|

--- a/spec/presenters/pafs_core/camc3_presenter_spec.rb
+++ b/spec/presenters/pafs_core/camc3_presenter_spec.rb
@@ -166,6 +166,18 @@ RSpec.describe PafsCore::Camc3Presenter do
       end
     end
 
+    describe "secondary_risk_sources" do
+      it "renders in the generated json" do
+        expect(subject.attributes).to have_key(:secondary_risk_sources)
+      end
+
+      it "contains all the risk attributes" do
+        PafsCore::Risks::RISKS.each do |sra|
+          expect(subject.attributes[:secondary_risk_sources]).to have_key(sra)
+        end
+      end
+    end
+
     shared_examples "has the expected forecast" do |outcomes_category, attribute, presenter_method = nil|
       before do
         funding_values.each do |hash|


### PR DESCRIPTION
PAFS - Add secondary risk source to JSON file
https://eaflood.atlassian.net/browse/RUBY-2436