### PR TITLE
Start CAMC3 export in project's first financial year

### DIFF
--- a/app/models/pafs_core/project.rb
+++ b/app/models/pafs_core/project.rb
@@ -142,6 +142,10 @@ module PafsCore
       end
     end
 
+    def first_financial_year
+      funding_values.pluck(:financial_year).min
+    end
+
     private
 
     def set_slug

--- a/app/presenters/pafs_core/camc3_presenter.rb
+++ b/app/presenters/pafs_core/camc3_presenter.rb
@@ -4,6 +4,9 @@ require "pafs_core/shapefile_serializer"
 
 module PafsCore
   class Camc3Presenter
+
+    include PafsCore::FinancialYear
+
     def initialize(project:)
       self.project = project
 
@@ -207,7 +210,8 @@ module PafsCore
     attr_accessor :project, :fcerm1_presenter, :pf_calculator_presenter, :fcerm1_mapper, :funding_sources_mapper
 
     def financial_years
-      [-1] + (2015..project.project_end_financial_year).to_a
+      start_year = project.first_financial_year || current_financial_year
+      (start_year..project.project_end_financial_year).to_a
     end
   end
 end

--- a/app/services/pafs_core/spreadsheet/contributors/coerce/financial_year.rb
+++ b/app/services/pafs_core/spreadsheet/contributors/coerce/financial_year.rb
@@ -6,8 +6,6 @@ module PafsCore
       module Coerce
         class FinancialYear < Base
           def perform
-            return -1 if value == "Previous years"
-
             raise("unknown year") if matches.nil?
 
             matches[0]

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -68,7 +68,7 @@ FactoryBot.define do
 
     after(:create) do |project, builder|
       if builder.create_funding_values
-        (2015..(builder.project_end_financial_year || 2023)).to_a.push(-1).each do |fy|
+        (2015..(builder.project_end_financial_year || 2023)).to_a.each do |fy|
           create(
             :funding_value,
             public_contribution_names: builder.public_contribution_names,

--- a/spec/lib/pafs_core/financial_year_spec.rb
+++ b/spec/lib/pafs_core/financial_year_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "PafsCore::FinancialYear" do
+
+  describe "#current_financial_year" do
+    let(:step) { build(:financial_year_step) }
+    let(:current_calendar_year) { Time.zone.today.year }
+
+    context "when the current date is in March" do
+      before { Timecop.freeze(Date.new(current_calendar_year, 3, 31)) }
+
+      it { expect(step.current_financial_year).to eq current_calendar_year - 1 }
+    end
+
+    context "when the current date is in April" do
+      before { Timecop.freeze(Date.new(current_calendar_year, 4, 1)) }
+
+      it { expect(step.current_financial_year).to eq current_calendar_year }
+    end
+  end
+end

--- a/spec/models/pafs_core/project_spec.rb
+++ b/spec/models/pafs_core/project_spec.rb
@@ -78,4 +78,20 @@ RSpec.describe PafsCore::Project do
       end
     end
   end
+
+  describe "#first_financial_year" do
+    let(:project) { create(:project, :with_funding_values) }
+
+    context "when all attributes have the same starting year" do
+      it { expect(project.first_financial_year).to eq(2015) }
+    end
+
+    context "when the attributes have different starting years" do
+      let(:earliest_year) { 2010 }
+
+      before { project.funding_values << build(:funding_value, financial_year: earliest_year) }
+
+      it { expect(project.first_financial_year).to eq earliest_year }
+    end
+  end
 end

--- a/spec/presenters/pafs_core/camc3_presenter_spec.rb
+++ b/spec/presenters/pafs_core/camc3_presenter_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe PafsCore::Camc3Presenter do
   end
   let(:funding_values) do
     [
-      { year: -1, value: 2000 },
       { year: 2015, value: 200  },
       { year: 2016, value: 250  },
       { year: 2017, value: 350  },
@@ -32,7 +31,6 @@ RSpec.describe PafsCore::Camc3Presenter do
   end
   let(:funding_years) do
     [
-      -1,
       2015,
       2016,
       2017,
@@ -43,7 +41,6 @@ RSpec.describe PafsCore::Camc3Presenter do
   end
   let(:outcome_measurements) do
     [
-      { year: -1, value: 2000 },
       { year: 2015, value: 200 },
       { year: 2016, value: 250 },
       { year: 2017, value: 350 },


### PR DESCRIPTION
This change starts the CAM3C JSON export from the project's first funding year, instead of a hardcoded year as was previously the case.
https://eaflood.atlassian.net/browse/RUBY-2554