### PR TITLE
[RUBY-2590] adding date validation for earliest_start_date_with_gia step

### DIFF
--- a/app/steps/pafs_core/earliest_start_date_with_gia_step.rb
+++ b/app/steps/pafs_core/earliest_start_date_with_gia_step.rb
@@ -5,10 +5,11 @@ module PafsCore
     delegate :could_start_early?,
              :earliest_with_gia_month, :earliest_with_gia_month=,
              :earliest_with_gia_year, :earliest_with_gia_year=,
-             :date_present?, :date_plausible?, :year_plausible?, :month_plausible?,
+             :date_present?, :date_plausible?, :year_plausible?,
+             :month_plausible?, :date_in_future?,
              to: :project
 
-    validate :date_is_present_and_plausible
+    validate :date_is_present_and_correct
 
     private
 
@@ -16,6 +17,13 @@ module PafsCore
       params.require(:earliest_start_date_with_gia_step).permit(
         :earliest_with_gia_month, :earliest_with_gia_year
       )
+    end
+
+    def date_is_present_and_correct
+      date_is_present_and_plausible
+      return if errors.any?
+
+      date_is_in_future
     end
 
     def date_is_present_and_plausible
@@ -36,6 +44,15 @@ module PafsCore
         :earliest_with_gia_date,
         "The year must be between #{PafsCore::DateUtils::VALID_YEAR_RANGE.first} " \
         "and #{PafsCore::DateUtils::VALID_YEAR_RANGE.last}"
+      )
+    end
+
+    def date_is_in_future
+      return unless date_present?("earliest_with_gia") && !date_in_future?("earliest_with_gia")
+
+      errors.add(
+        :earliest_with_gia_date,
+        "You cannot enter a date in the past"
       )
     end
   end

--- a/spec/steps/pafs_core/earliest_start_date_with_gia_step_spec.rb
+++ b/spec/steps/pafs_core/earliest_start_date_with_gia_step_spec.rb
@@ -44,15 +44,23 @@ RSpec.describe PafsCore::EarliestStartDateWithGiaStep, type: :model do
       expect(subject.valid?).to be false
       expect(subject.errors.messages[:earliest_with_gia_date].first).to eq "The year must be between 2000 and 2100"
     end
+
+    it "validates that :earliest_start is in future" do
+      subject.earliest_with_gia_month = 2
+      subject.earliest_with_gia_year = 2020
+      expect(subject.valid?).to be false
+      expect(subject.errors.messages[:earliest_with_gia_date].first).to eq "You cannot enter a date in the past"
+    end
   end
 
   describe "#update" do
-    subject { create(:earliest_start_date_with_gia_step) }
+    subject { create(:earliest_start_date_with_gia_step, earliest_with_gia_year: 2030, earliest_with_gia_month: 2) }
 
+    let(:next_year) { Time.zone.today.year + 1 }
     let(:valid_params) do
       ActionController::Parameters.new(
         { earliest_start_date_with_gia_step:
-          { earliest_with_gia_month: "11", earliest_with_gia_year: "2016" } }
+          { earliest_with_gia_month: "11", earliest_with_gia_year: next_year.to_s } }
       )
     end
     let(:error_params) do
@@ -65,7 +73,7 @@ RSpec.describe PafsCore::EarliestStartDateWithGiaStep, type: :model do
     it "saves the date params when valid" do
       expect(subject.update(valid_params)).to be true
       expect(subject.earliest_with_gia_month).to eq 11
-      expect(subject.earliest_with_gia_year).to eq 2016
+      expect(subject.earliest_with_gia_year).to eq next_year
     end
 
     it "returns false when validation fails" do


### PR DESCRIPTION
Validation on date field - 'What is the earliest date the project could start if Grant in Aid funding was made available earlier?'
https://eaflood.atlassian.net/browse/RUBY-2590
