### PR TITLE
[RUBY-2593] zeroing risk values for Camc3Presenter when no risks selected

### DIFF
--- a/app/presenters/pafs_core/camc3_presenter.rb
+++ b/app/presenters/pafs_core/camc3_presenter.rb
@@ -20,7 +20,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.households_at_reduced_risk(year)
+          value: zero_unless_flooding(fcerm1_presenter.households_at_reduced_risk(year))
         }
       end
     end
@@ -29,7 +29,9 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.moved_from_very_significant_and_significant_to_moderate_or_low(year)
+          value: zero_unless_flooding(
+            fcerm1_presenter.moved_from_very_significant_and_significant_to_moderate_or_low(year)
+          )
         }
       end
     end
@@ -38,7 +40,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.households_protected_from_loss_in_20_percent_most_deprived(year)
+          value: zero_unless_flooding(fcerm1_presenter.households_protected_from_loss_in_20_percent_most_deprived(year))
         }
       end
     end
@@ -47,7 +49,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.households_protected_through_plp_measures(year)
+          value: zero_unless_flooding(fcerm1_presenter.households_protected_through_plp_measures(year))
         }
       end
     end
@@ -56,7 +58,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.non_residential_properties(year)
+          value: zero_unless_flooding(fcerm1_presenter.non_residential_properties(year))
         }
       end
     end
@@ -65,7 +67,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.households_at_reduced_risk_2040(year)
+          value: zero_unless_flooding(fcerm1_presenter.households_at_reduced_risk_2040(year))
         }
       end
     end
@@ -74,7 +76,9 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.moved_from_very_significant_and_significant_to_moderate_or_low_2040(year)
+          value: zero_unless_flooding(
+            fcerm1_presenter.moved_from_very_significant_and_significant_to_moderate_or_low_2040(year)
+          )
         }
       end
     end
@@ -83,7 +87,9 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.households_protected_from_loss_in_20_percent_most_deprived_2040(year)
+          value: zero_unless_flooding(
+            fcerm1_presenter.households_protected_from_loss_in_20_percent_most_deprived_2040(year)
+          )
         }
       end
     end
@@ -92,7 +98,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.non_residential_properties_2040(year)
+          value: zero_unless_flooding(fcerm1_presenter.non_residential_properties_2040(year))
         }
       end
     end
@@ -101,7 +107,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.coastal_households_at_reduced_risk(year)
+          value: zero_unless_coastal_erosion(fcerm1_presenter.coastal_households_at_reduced_risk(year))
         }
       end
     end
@@ -110,7 +116,9 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.coastal_households_protected_from_loss_in_next_20_years(year)
+          value: zero_unless_coastal_erosion(
+            fcerm1_presenter.coastal_households_protected_from_loss_in_next_20_years(year)
+          )
         }
       end
     end
@@ -119,7 +127,9 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.coastal_households_protected_from_loss_in_20_percent_most_deprived(year)
+          value: zero_unless_coastal_erosion(
+            fcerm1_presenter.coastal_households_protected_from_loss_in_20_percent_most_deprived(year)
+          )
         }
       end
     end
@@ -128,7 +138,7 @@ module PafsCore
       financial_years.collect do |year|
         {
           year: year,
-          value: fcerm1_presenter.coastal_non_residential_properties(year)
+          value: zero_unless_coastal_erosion(fcerm1_presenter.coastal_non_residential_properties(year))
         }
       end
     end
@@ -212,6 +222,14 @@ module PafsCore
     def financial_years
       start_year = project.first_financial_year || current_financial_year
       (start_year..project.project_end_financial_year).to_a
+    end
+
+    def zero_unless_flooding(value)
+      project.flooding? ? value : 0
+    end
+
+    def zero_unless_coastal_erosion(value)
+      project.coastal_erosion? ? value : 0
     end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -112,6 +112,7 @@ FactoryBot.define do
       earliest_start_year { 2017 }
       fluvial_flooding { true }
       sea_flooding { true }
+      coastal_erosion { true }
       main_risk { "sea_flooding" }
       project_location { [457_733, 221_751] }
       project_location_zoom_level { 15 }

--- a/spec/presenters/pafs_core/camc3_presenter_spec.rb
+++ b/spec/presenters/pafs_core/camc3_presenter_spec.rb
@@ -61,6 +61,28 @@ RSpec.describe PafsCore::Camc3Presenter do
       { year: 2032, value: 0 }
     ]
   end
+  let(:zero_outcome_measurements) do
+    [
+      { year: 2015, value: 0 },
+      { year: 2016, value: 0 },
+      { year: 2017, value: 0 },
+      { year: 2018, value: 0 },
+      { year: 2019, value: 0 },
+      { year: 2020, value: 0 },
+      { year: 2021, value: 0 },
+      { year: 2022, value: 0 },
+      { year: 2023, value: 0 },
+      { year: 2024, value: 0 },
+      { year: 2025, value: 0 },
+      { year: 2026, value: 0 },
+      { year: 2027, value: 0 },
+      { year: 2028, value: 0 },
+      { year: 2029, value: 0 },
+      { year: 2030, value: 0 },
+      { year: 2031, value: 0 },
+      { year: 2032, value: 0 }
+    ]
+  end
   let(:json) { subject.attributes.to_json }
 
   before do
@@ -202,8 +224,18 @@ RSpec.describe PafsCore::Camc3Presenter do
         end
       end
 
-      it "has the forecast for #{attribute.to_s.humanize}" do
-        expect(subject.send(presenter_method || attribute)).to eql(outcome_measurements)
+      context "when risk category selected" do
+        it "has the forecast for #{attribute.to_s.humanize}" do
+          expect(project.flooding? || project.coastal_erosion?).to be_truthy
+          expect(subject.send(presenter_method || attribute)).to eql(outcome_measurements)
+        end
+      end
+
+      context "when no risk category selected" do
+        it "returns 0 forecast for #{attribute.to_s.humanize}" do
+          project.assign_attributes(PafsCore::Risks::RISKS.index_with { nil })
+          expect(subject.send(presenter_method || attribute)).to eql(zero_outcome_measurements)
+        end
       end
     end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-2593
Fixing bug with risk values being exported to JSON even when no risk category is selected