### PR TITLE
[RUBY-3226] Update `defra_ruby_template` dependency to version 5.0 in Gemfile.lock and pafs_core.gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
       bstard
       clamav-client
       defra_ruby_alert (~> 2.2)
-      defra_ruby_template (~> 3)
+      defra_ruby_template (~> 5.0)
       faraday
       faraday-retry
       govuk_design_system_formbuilder (~> 3)
@@ -187,7 +187,7 @@ GEM
       rubocop-factory_bot
       rubocop-rake
       rubocop-rspec
-    defra_ruby_template (3.15.1)
+    defra_ruby_template (5.4.1)
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (3.1.2)

--- a/pafs_core.gemspec
+++ b/pafs_core.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency "defra_ruby_alert", "~> 2.2"
 
   # GOV.UK styling
-  s.add_dependency "defra_ruby_template", "~> 3"
+  s.add_dependency "defra_ruby_template", "~> 5.0"
+
   s.add_dependency "govuk_design_system_formbuilder", "~> 3"
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3226
Upgrade defra_ruby_template version to v5.4.0