### PR TITLE
[RUBY-3843] Handle errors during Partnership Funding Calculator file parsing to prevent 403 errors

### DIFF
--- a/app/steps/pafs_core/funding_calculator_step.rb
+++ b/app/steps/pafs_core/funding_calculator_step.rb
@@ -36,7 +36,18 @@ module PafsCore
           filename = File.basename(uploaded_file.original_filename)
           dest_file = File.join(storage_path, filename)
           storage.upload(uploaded_file.tempfile.path, dest_file)
-          PafsCore::CalculatorParser.parse(uploaded_file, project)
+
+          begin
+            PafsCore::CalculatorParser.parse(uploaded_file, project)
+          rescue StandardError
+            errors.add(
+              :funding_calculator,
+              "The file could not be processed. Please ensure you're using the correct " \
+              "Partnership Funding Calculator version."
+            )
+            storage.delete(dest_file)
+            return false
+          end
 
           if old_file && old_file != filename
             # aws doesn't raise an error if it cannot find the key when deleting


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3843

- Added error handling around `PafsCore::CalculatorParser.parse` to catch parsing exceptions.
- On error, add a user-friendly message and delete the uploaded file to clean up storage.
- Updated specs to test error handling, ensuring proper error messages, file cleanup, and update method returns false.
