### PR TITLE
[RUBY-3822] Update environmental benefits validation to return specific error message and fix specs

### DIFF
--- a/app/presenters/pafs_core/validation_presenter.rb
+++ b/app/presenters/pafs_core/validation_presenter.rb
@@ -292,7 +292,7 @@ module PafsCore
 
       return true unless environmental_benefits?
 
-      return false if selected_om4_attributes.empty?
+      return outcomes_error if selected_om4_attributes.empty?
 
       check_intertidal && check_woodland && check_wet_woodland && check_wetland_or_wet_grassland &&
         check_grassland && check_heathland && check_pond_or_lake && check_arable_land &&
@@ -438,7 +438,7 @@ module PafsCore
 
     def outcomes_error
       add_error(:environmental_outcomes,
-                "Tell us the project’s environmental outcomes")
+                "Tell us the project's environmental outcomes")
     end
 
     def check_flooding

--- a/spec/presenters/pafs_core/validation_presenter_spec.rb
+++ b/spec/presenters/pafs_core/validation_presenter_spec.rb
@@ -384,7 +384,7 @@ RSpec.describe PafsCore::ValidationPresenter do
       before { subject.environmental_benefits = true }
 
       context "when no environmental benefits have been selected" do
-        it_behaves_like "failed validation example", :environmental_outcomes_complete?
+        it_behaves_like "failed validation example", :environmental_outcomes_complete?, :environmental_outcomes, "Tell us the project's environmental outcomes"
       end
 
       context "when at least one environmental benefit has been elected" do


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-3822

Correctly show error when a user does not select any environmental outcomes so user knows why their project is not being sent to PD

- Changed `environmental_outcomes_complete?` to return `outcomes_error` instead of `false` when no environmental benefits are selected.
- Updated error message to use correct apostrophe in "project's".
- Modified spec to check for the specific error and message in validation tests.
