### PR TITLE
[RUBY-3937] Update Magic Map link and polygon drawing instructions

### DIFF
--- a/app/views/pafs_core/projects/steps/benefit_area_file.html.erb
+++ b/app/views/pafs_core/projects/steps/benefit_area_file.html.erb
@@ -37,7 +37,7 @@
       </summary>
       <div class="govuk-details__text" id="shapefile-instructions">
         <p>You can use your own mapping tool or our recommended tool - Magic Map (free to use) - to draw your project’s benefit area</p>
-        <p><a href='https://magic.defra.gov.uk/magicmap.aspx', target='_blank', rel='noopener'>Magic Map (opens in a new window)</a></p>
+        <p><a href='https://magic.defra.gov.uk/MagicMap.html', target='_blank', rel='noopener'>Magic Map Application (opens in a new window)</a></p>
 
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
@@ -46,19 +46,18 @@
           <div class="govuk-details__text" id="polygon-instructions">
             <p>Follow these simple steps to create and upload your polygon:</p>
             <ol class="instructions">
-              <li>Click on the Mapping tool link above to open the Magic Map tool</li>
-              <li>
-                Use the search field on the top left-hand corner, to zoom in on your area of benefit. 
-                The black arrow within the search allows you to choose your preferred method to zoom in 
-                (e.g. postcode, grid ref. etc)
-              </li>
-              <li>Click on the 'Drawing Tools' pallet icon</li>
-              <li>Click on the Polygon (or Freehand Polygon) icon</li>
-              <li>Click to start and finish your polygon drawing</li>
-              <li>If you want to start again you can use the X icon to clear</li>
-              <li>Click on the ‘Export’ button. The Shapefile ZIP will download to your machine.</li>
-              <li>Go to your computer download folder, to view your file, at this point you can rename</li>
-              <li>Return to PAFs, then upload and continue</li>
+              <li>Click on the Mapping tool link above to open the Magic Map tool.</li>
+              <li>Use the search field on the top left-hand corner, to zoom in on your area of benefit. The arrow pointing downwards allows you to choose your preferred method to zoom in (e.g. postcode, grid ref. etc)</li>
+              <li>Click on the ‘Drawing Tool’ icon.</li>
+              <li>Click on the Polygon icon.</li>
+              <li>Now click to start your first vertices and then select to draw your polygon.</li>
+              <li>Double click to complete your shape.</li>
+              <li>If you want to start again you can select the rubbish bin icon in the Sketch Styler menu.</li>
+              <li>When you are happy with the shape that you have drawn select on the polygon, it should go blue with an orange box around it.</li>
+              <li>Now select the Save Graphics menu within the Sketch Styler menu and select Save.</li>
+              <li>The Shape file ZIP will download to your machine.</li>
+              <li>Go to your computers download folder, to view your file, at this point you can rename it.</li>
+              <li>Return to PAFs, then upload and continue.</li>
             </ol>
           </div>
         </details>


### PR DESCRIPTION
- Changed Magic Map URL to https://magic.defra.gov.uk/MagicMap.html and updated link text.
- Revised step-by-step instructions for drawing and exporting polygons using the Magic Map tool for clarity and accuracy.
