### PR TITLE
Feature/ruby 3800 post qa adjustments

### DIFF
--- a/app/presenters/pafs_core/carbon_impact_presenter.rb
+++ b/app/presenters/pafs_core/carbon_impact_presenter.rb
@@ -129,11 +129,11 @@ module PafsCore
       format_carbon_value(project.carbon_cost_operation)
     end
 
-    def display_total_carbon_without_mitigations
+    def display_total_carbon_without_mitigations(units: I18n.t("pafs_core.projects.steps.carbon_summary.units"))
       return NOT_PROVIDED if project.carbon_cost_build.nil? && project.carbon_cost_operation.nil?
 
       "#{number_with_precision(total_carbon_without_mitigations, delimiter: ',', precision: 2)} " \
-        "#{I18n.t('pafs_core.projects.steps.carbon_summary.units')}"
+        "#{units}"
     end
 
     def display_carbon_cost_sequestered
@@ -144,11 +144,11 @@ module PafsCore
       format_carbon_value(project.carbon_cost_avoided)
     end
 
-    def display_net_carbon_estimate
+    def display_net_carbon_estimate(units: I18n.t("pafs_core.projects.steps.carbon_summary.units"))
       return NOT_PROVIDED if all_carbon_values_nil?
 
       "#{number_with_precision(net_carbon_estimate, delimiter: ',', precision: 2)} " \
-        "#{I18n.t('pafs_core.projects.steps.carbon_summary.units')}"
+        "#{units}"
     end
 
     def display_carbon_savings_net_economic_benefit

--- a/app/steps/pafs_core/net_carbon_step.rb
+++ b/app/steps/pafs_core/net_carbon_step.rb
@@ -9,15 +9,8 @@ module PafsCore
       true
     end
 
-    def net_carbon_required_fields_empty?
-      project.carbon_cost_build.blank? &&
-        project.carbon_cost_operation.blank? &&
-        project.carbon_cost_sequestered.blank? &&
-        project.carbon_cost_avoided.blank?
-    end
-
-    def carbon_impact_presenter
-      @carbon_impact_presenter ||= PafsCore::CarbonImpactPresenter.new(project: project)
+    def presenter
+      @presenter ||= PafsCore::CarbonImpactPresenter.new(project: project)
     end
   end
 end

--- a/app/steps/pafs_core/whole_life_carbon_step.rb
+++ b/app/steps/pafs_core/whole_life_carbon_step.rb
@@ -9,13 +9,8 @@ module PafsCore
       true
     end
 
-    def whole_life_carbon_required_fields_empty?
-      project.carbon_cost_build.blank? &&
-        project.carbon_cost_operation.blank?
-    end
-
-    def carbon_impact_presenter
-      @carbon_impact_presenter ||= PafsCore::CarbonImpactPresenter.new(project: project)
+    def presenter
+      @presenter ||= PafsCore::CarbonImpactPresenter.new(project: project)
     end
   end
 end

--- a/app/views/pafs_core/projects/steps/net_carbon.html.erb
+++ b/app/views/pafs_core/projects/steps/net_carbon.html.erb
@@ -12,11 +12,7 @@
               </p>
 
               <p><b>
-                <% if @project.net_carbon_required_fields_empty? %>
-                  <%= t(".not_provided") %>
-                <% else %>
-                  <%= @project.carbon_impact_presenter.net_carbon_estimate %> <%= t(".units") %>
-                <% end %>
+                <%= @project.presenter.display_net_carbon_estimate(units: t(".units")) %>
               </b></p>
 
               <%= f.govuk_submit t(".submit_button"), class: 'button' %>

--- a/app/views/pafs_core/projects/steps/whole_life_carbon.html.erb
+++ b/app/views/pafs_core/projects/steps/whole_life_carbon.html.erb
@@ -12,7 +12,7 @@
               </p>
 
               <p><b>
-                <%= @project.presenter.display_total_carbon_without_mitigations %>
+                <%= @project.presenter.display_total_carbon_without_mitigations(units: t(".units")) %>
               </b></p>
 
               <%= f.govuk_submit t(".submit_button"), class: 'button' %>

--- a/app/views/pafs_core/projects/steps/whole_life_carbon.html.erb
+++ b/app/views/pafs_core/projects/steps/whole_life_carbon.html.erb
@@ -12,11 +12,7 @@
               </p>
 
               <p><b>
-                <% if @project.whole_life_carbon_required_fields_empty? %>
-                  <%= t(".not_provided") %>
-                <% else %>
-                  <%= @project.carbon_impact_presenter.total_carbon_without_mitigations %> <%= t(".units") %>
-                <% end %>
+                <%= @project.presenter.display_total_carbon_without_mitigations %>
               </b></p>
 
               <%= f.govuk_submit t(".submit_button"), class: 'button' %>

--- a/spec/presenters/pafs_core/carbon_impact_presenter_spec.rb
+++ b/spec/presenters/pafs_core/carbon_impact_presenter_spec.rb
@@ -289,6 +289,11 @@ RSpec.describe PafsCore::CarbonImpactPresenter do
       project.carbon_cost_build = 1000.00
       expect(subject.display_total_carbon_without_mitigations).to eq("1,000.00 tonnes")
     end
+
+    it "returns formatted field value with custom units" do
+      project.carbon_cost_build = 1234.56
+      expect(subject.display_total_carbon_without_mitigations(units: "metric tonnes")).to eq("1,234.56 metric tonnes")
+    end
   end
 
   describe "#display_carbon_cost_sequestered" do
@@ -311,6 +316,11 @@ RSpec.describe PafsCore::CarbonImpactPresenter do
     it "returns formatted field value when at least one carbon field is present" do
       project.carbon_cost_build = 500.00
       expect(subject.display_net_carbon_estimate).to eq("500.00 tonnes")
+    end
+
+    it "returns formatted field value with custom units" do
+      project.carbon_cost_build = 1234.56
+      expect(subject.display_net_carbon_estimate(units: "metric tonnes")).to eq("1,234.56 metric tonnes")
     end
   end
 

--- a/spec/steps/pafs_core/net_carbon_step_spec.rb
+++ b/spec/steps/pafs_core/net_carbon_step_spec.rb
@@ -9,26 +9,9 @@ RSpec.describe PafsCore::NetCarbonStep, type: :model do
 
   it_behaves_like "does not modify project attributes"
 
-  describe "#net_carbon_required_fields_empty?" do
-    it "returns true if all carbon cost fields are blank" do
-      subject.project.carbon_cost_build = nil
-      subject.project.carbon_cost_operation = nil
-      subject.project.carbon_cost_sequestered = nil
-      subject.project.carbon_cost_avoided = nil
-
-      expect(subject.net_carbon_required_fields_empty?).to be true
-    end
-
-    it "returns false if any carbon cost field is present" do
-      subject.project.carbon_cost_build = 100
-
-      expect(subject.net_carbon_required_fields_empty?).to be false
-    end
-  end
-
-  describe "#carbon_impact_presenter" do
+  describe "#presenter" do
     it "returns a CarbonImpactPresenter instance" do
-      presenter = subject.carbon_impact_presenter
+      presenter = subject.presenter
       expect(presenter).to be_a(PafsCore::CarbonImpactPresenter)
     end
   end

--- a/spec/steps/pafs_core/whole_life_carbon_step_spec.rb
+++ b/spec/steps/pafs_core/whole_life_carbon_step_spec.rb
@@ -9,22 +9,9 @@ RSpec.describe PafsCore::WholeLifeCarbonStep, type: :model do
 
   it_behaves_like "does not modify project attributes"
 
-  describe "#whole_life_carbon_required_fields_empty?" do
-    it "returns true if all carbon cost fields are blank" do
-      subject.project.carbon_cost_build = nil
-      subject.project.carbon_cost_operation = nil
-      expect(subject.whole_life_carbon_required_fields_empty?).to be true
-    end
-
-    it "returns false if any carbon cost field is present" do
-      subject.project.carbon_cost_build = 100
-      expect(subject.whole_life_carbon_required_fields_empty?).to be false
-    end
-  end
-
-  describe "#carbon_impact_presenter" do
+  describe "#presenter" do
     it "returns a CarbonImpactPresenter instance" do
-      presenter = subject.carbon_impact_presenter
+      presenter = subject.presenter
       expect(presenter).to be_a(PafsCore::CarbonImpactPresenter)
     end
   end


### PR DESCRIPTION
Post-QA adjustments for Carbon Net Zero

Carbon Net Zero - 4 - Whole life carbon page RUBY-3923
- Show values to two decimal places, not one

Carbon Net Zero - 7 - Net carbon page RUBY-3926
- Show values to two decimal places, not one
